### PR TITLE
Fix http stream corrupted stack

### DIFF
--- a/src/common/pointer.hpp
+++ b/src/common/pointer.hpp
@@ -1,0 +1,38 @@
+/*-
+ * This file is part of Libight <https://libight.github.io/>.
+ *
+ * Libight is free software. See AUTHORS and LICENSE for more
+ * information on the copying conditions.
+ */
+
+#ifndef LIBIGHT_COMMON_POINTER_HPP
+# define LIBIGHT_COMMON_POINTER_HPP
+
+#include <memory>
+#include <stdexcept>
+
+namespace ight {
+namespace common {
+namespace pointer {
+
+template<typename T> class SharedPointer : public std::shared_ptr<T> {
+    using std::shared_ptr<T>::shared_ptr;
+
+public:
+    T *operator->() {
+        if (this->get() == nullptr) {
+            throw std::runtime_error("null pointer");
+        }
+        return std::shared_ptr<T>::operator->();
+    }
+
+    typename std::add_lvalue_reference<T>::type operator*() {
+        if (this->get() == nullptr) {
+            throw std::runtime_error("null pointer");
+        }
+        return std::shared_ptr<T>::operator*();
+    }
+};
+
+}}}  // namespaces
+#endif  // LIBIGHT_COMMON_POINTER_HPP

--- a/src/protocols/http.hpp
+++ b/src/protocols/http.hpp
@@ -270,6 +270,7 @@ public:
     Stream(Stream&& other) {
         std::swap(connection, other.connection);
         std::swap(parser, other.parser);
+        std::swap(error_handler, other.error_handler);
     }
 
     /*!
@@ -278,6 +279,7 @@ public:
     Stream& operator=(Stream&& other) {
         std::swap(connection, other.connection);
         std::swap(parser, other.parser);
+        std::swap(error_handler, other.error_handler);
         return *this;
     }
 

--- a/src/protocols/http.hpp
+++ b/src/protocols/http.hpp
@@ -633,12 +633,14 @@ public:
         std::swap(serializer, other.serializer);
         std::swap(stream, other.stream);
         std::swap(response, other.response);
+        std::swap(parent, other.parent);
     }
     Request& operator=(Request&& other) {
         std::swap(callback, other.callback);
         std::swap(serializer, other.serializer);
         std::swap(stream, other.stream);
         std::swap(response, other.response);
+        std::swap(parent, other.parent);
         return *this;
     }
 

--- a/src/protocols/http.hpp
+++ b/src/protocols/http.hpp
@@ -231,24 +231,25 @@ class Stream {
     ResponseParser parser;
     std::function<void(IghtError)> error_handler;
 
+    void handle_error(IghtError error) {
+        //
+        // Intercept EOF error to implement body-ends-at-EOF semantic.
+        // TODO: convert error from integer to exception.
+        //
+        if (error.error == 0) {
+            parser.eof();
+        }
+        if (error_handler) {
+            error_handler(error);
+        }
+    }
+
     void connection_ready(void) {
         if (connection.enable_read() != 0) {
             throw std::runtime_error("Cannot enable read");
         }
         connection.on_data([&](evbuffer *data) {
             parser.feed(data);
-        });
-        //
-        // Intercept EOF error to implement body-ends-at-EOF semantic.
-        // TODO: convert error from integer to exception.
-        //
-        connection.on_error([&](IghtError error) {
-            if (error.error == 0) {
-                parser.eof();
-            }
-            if (error_handler) {
-                error_handler(error);
-            }
         });
     }
 
@@ -271,6 +272,29 @@ public:
         std::swap(connection, other.connection);
         std::swap(parser, other.parser);
         std::swap(error_handler, other.error_handler);
+
+        //
+        // FIXME Since this object is being moved, we need to change
+        //       the target of the registered callbacks so that
+        //       they bind to the correct `this`, otherwise they
+        //       are bound to a `this` that will soon be dead.
+        //
+        //       Note that the following is *not* enough to guarantee
+        //       the correct behavior because there are other bound
+        //       callbacks. Hence the `fixme` comment.
+        //
+        //       To be sure, one should allocate on the heap using new
+        //       and then rely on smart pointers, so `this` is never
+        //       relocated and it would also help to deny copy and move.
+        //
+        //       Yet, I'm adding this fix to illustrate that the
+        //       few lines of code below are enough to fix the regress
+        //       test that is currently crashing.
+        //
+        connection.on_error([this](IghtError error) {
+            handle_error(error);
+        });
+
     }
 
     /*!
@@ -280,6 +304,12 @@ public:
         std::swap(connection, other.connection);
         std::swap(parser, other.parser);
         std::swap(error_handler, other.error_handler);
+
+        // FIXME: See above...
+        connection.on_error([this](IghtError error) {
+            handle_error(error);
+        });
+
         return *this;
     }
 
@@ -306,15 +336,8 @@ public:
             std::string family = "PF_UNSPEC") {
         connection = IghtConnection(family.c_str(), address.c_str(),
                 port.c_str());
-        //
-        // While the connection is in progress, just forward the
-        // error if needed, we'll deal with body-terminated-by-EOF
-        // semantic when we know we are actually connected.
-        //
         connection.on_error([&](IghtError error) {
-            if (error_handler) {
-                error_handler(error);
-            }
+            handle_error(error);
         });
     }
 

--- a/test/protocols/http.cpp
+++ b/test/protocols/http.cpp
@@ -214,6 +214,34 @@ TEST_CASE("HTTP Request works as expected") {
     ight_loop();
 }
 
+TEST_CASE("HTTP Request correctly receives errors") {
+    ight_set_verbose(1);
+    auto r = http::Request({
+        {"url", "http://nexa.polito.it:81/robots.txt"},
+        {"method", "GET"},
+        {"http_version", "HTTP/1.1"},
+    }, {
+        {"Accept", "*/*"},
+    }, "", [&](IghtError error, http::Response&& response) {
+        if (error.error) {
+            std::cout << "Error: " << error.error << "\r\n";
+            ight_break_loop();
+            return;
+        }
+        std::cout << "HTTP/" << response.http_major << "."
+                << response.http_minor << " " << response.status_code
+                << " " << response.reason << "\r\n";
+        for (auto& kv : response.headers) {
+            std::cout << kv.first << ": " << kv.second << "\r\n";
+        }
+        std::cout << "\r\n";
+        std::cout << response.body.read<char>(128) << "\r\n";
+        std::cout << "[snip]\r\n";
+        ight_break_loop();
+    });
+    ight_loop();
+}
+
 TEST_CASE("HTTP Client works as expected") {
     //ight_set_verbose(1);
     auto client = http::Client();


### PR DESCRIPTION
This pull request fixes a 'corrupted stack' error in http::Stream that leads to a crash. The crash reason is quite stupid (once I realized it); http::Stream shall not be allocated on the stack because its `this` is captured by a few lambdas. Therefore, after http::Stream is moved, the captured `this` is no longer valid.

Fix by using SharedPointer and allocating http::Stream on the heap.