### PR TITLE
Add SharedPointer<T> smart pointer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ test/common/bufferevent
 test/common/delayed_call
 test/common/evbuffer
 test/common/poller
+test/common/pointer
 test/common/socket_valid
 test/echo_client
 test/echo_client2

--- a/src/common/pointer.hpp
+++ b/src/common/pointer.hpp
@@ -1,0 +1,38 @@
+/*-
+ * This file is part of Libight <https://libight.github.io/>.
+ *
+ * Libight is free software. See AUTHORS and LICENSE for more
+ * information on the copying conditions.
+ */
+
+#ifndef LIBIGHT_COMMON_POINTER_HPP
+# define LIBIGHT_COMMON_POINTER_HPP
+
+#include <memory>
+#include <stdexcept>
+
+namespace ight {
+namespace common {
+namespace pointer {
+
+template<typename T> class SharedPointer : public std::shared_ptr<T> {
+    using std::shared_ptr<T>::shared_ptr;
+
+public:
+    T *operator->() {
+        if (this->get() == nullptr) {
+            throw std::runtime_error("null pointer");
+        }
+        return std::shared_ptr<T>::operator->();
+    }
+
+    typename std::add_lvalue_reference<T>::type operator*() {
+        if (this->get() == nullptr) {
+            throw std::runtime_error("null pointer");
+        }
+        return std::shared_ptr<T>::operator*();
+    }
+};
+
+}}}  // namespaces
+#endif  // LIBIGHT_COMMON_POINTER_HPP

--- a/src/common/pointer.hpp
+++ b/src/common/pointer.hpp
@@ -15,10 +15,41 @@ namespace ight {
 namespace common {
 namespace pointer {
 
+/*!
+ * \brief Improved std::shared_ptr<T> with null pointer checks.
+ *
+ * This template class is a drop-in replacemente for the standard library's
+ * shared_ptr<>. It extends shared_ptr<>'s ->() and *() operators to check
+ * whether the pointee is a nullptr. In such case, unlike shared_ptr<>, the
+ * pointee is not accessed and a runtime exception is raised.
+ *
+ * Use this class as follows:
+ *
+ *     using namespace ight::common::pointer;
+ *     ...
+ *     SharedPointer<Foo> ptr;
+ *     ...
+ *     ptr = std::make_shared<Foo>(...);
+ *
+ * That is, declare ptr as SharedPointer<Foo> and the behave like ptr was
+ * a shared_ptr<> variable instead.
+ *
+ * It is safe to assign the return value of std::make_shared<Foo> to
+ * SharedPointer<Foo> because SharedPointer have exactly the same fields
+ * as std::shared_pointer and because it inherits the copy and move
+ * constructors from std::shared_pointer.
+ */
 template<typename T> class SharedPointer : public std::shared_ptr<T> {
     using std::shared_ptr<T>::shared_ptr;
 
 public:
+
+    /*!
+     * \brief Access the pointee to get one of its fields.
+     * \returns A pointer to the pointee that allows one to access
+     *          the requested pointee field.
+     * \throws std::runtime_error if the pointee is nullptr.
+     */
     T *operator->() {
         if (this->get() == nullptr) {
             throw std::runtime_error("null pointer");
@@ -26,6 +57,11 @@ public:
         return std::shared_ptr<T>::operator->();
     }
 
+    /*!
+     * \brief Get the value of the pointee.
+     * \returns The value of the pointee.
+     * \throws std::runtime_error if the pointee is nullptr.
+     */
     typename std::add_lvalue_reference<T>::type operator*() {
         if (this->get() == nullptr) {
             throw std::runtime_error("null pointer");

--- a/test/common/pointer.cpp
+++ b/test/common/pointer.cpp
@@ -1,0 +1,43 @@
+/*-
+ * This file is part of Libight <https://libight.github.io/>.
+ *
+ * Libight is free software. See AUTHORS and LICENSE for more
+ * information on the copying conditions.
+ */
+
+//
+// Tests for src/common/pointer.hpp
+//
+
+#define CATCH_CONFIG_MAIN
+#include "src/ext/Catch/single_include/catch.hpp"
+
+#include "src/common/pointer.hpp"
+
+using namespace ight::common::pointer;
+
+struct Foo {
+    double elem = 3.14;
+    Foo() {}
+    Foo(double x) : elem(x) {}
+};
+
+TEST_CASE("SharedPointer raises an exception when the pointee is nullptr") {
+    SharedPointer<Foo> foo;
+    REQUIRE_THROWS(auto k = foo->elem);
+    REQUIRE_THROWS(*foo);
+}
+
+TEST_CASE("We can safely assign to SharedPointer an empty shared_ptr") {
+    std::shared_ptr<Foo> antani;
+    SharedPointer<Foo> necchi = antani;
+    REQUIRE_THROWS(auto k = necchi->elem);
+    REQUIRE_THROWS(*necchi);
+}
+
+TEST_CASE("We can assign to SharedPointer the result of make_shared") {
+    SharedPointer<Foo> necchi = std::make_shared<Foo>(6.28);
+    REQUIRE(necchi->elem == 6.28);
+    auto foo = *necchi;
+    REQUIRE(foo.elem == 6.28);
+}

--- a/test/include.am
+++ b/test/include.am
@@ -33,6 +33,11 @@ test_common_poller_LDADD = libight.la
 check_PROGRAMS += test/common/poller
 TESTS += test/common/poller
 
+test_common_pointer_SOURCES = test/common/pointer.cpp
+test_common_pointer_LDADD = libight.la
+check_PROGRAMS += test/common/pointer
+TESTS += test/common/pointer
+
 test_common_socket_valid_SOURCES = test/common/socket_valid.cpp
 test_common_socket_valid_LDADD = libight.la
 check_PROGRAMS += test/common/socket_valid


### PR DESCRIPTION
This pull request adds the `SharedPointer<T>` template smart pointer. This extends the standard `std::shared_ptr<T>` to check whether the pointee is `nullptr` each time the pointer is accessed. The way in which `SharedPointer<T>` is implemented is such that you can assign it the result of the standard `std::make_shared<T>()` function template.

I have already used the `SharedPointer<T>` template to fix a couple of bugs in pull requests #60 and #61.