### PR TITLE
Start to fix move semantic

### DIFF
--- a/src/common/check_connectivity.hpp
+++ b/src/common/check_connectivity.hpp
@@ -12,11 +12,15 @@
 // Helper class to check whether we have connectivity
 //
 
+#include "common/constraints.hpp"
+
 // Forward declarations
 struct event_base;
 struct evdns_base;
 
 namespace ight {
+
+using namespace ight::common::constraints;
 
 /*!
  * \brief Class used to check whether the network is up.
@@ -48,7 +52,7 @@ namespace ight {
  * the current thread is blocked until the DNS response is received or until
  * the evdns timeout expires.
  */
-class Network {
+class Network : public NonCopyable, public NonMovable {
     event_base *evbase = NULL;
     evdns_base *dnsbase = NULL;
     bool is_up = false;
@@ -63,11 +67,6 @@ class Network {
     ~Network(void) {
         cleanup();
     }
-
-    Network(Network& /*other*/) = delete;
-    Network& operator=(Network& /*other*/) = delete;
-    Network(Network&& /*other*/) = delete;
-    Network& operator=(Network&& /*other*/) = delete;
 
 public:
 

--- a/src/common/constraints.hpp
+++ b/src/common/constraints.hpp
@@ -1,0 +1,28 @@
+/*-
+ * This file is part of Libight <https://libight.github.io/>.
+ *
+ * Libight is free software. See AUTHORS and LICENSE for more
+ * information on the copying conditions.
+ */
+
+#ifndef LIBIGHT_COMMON_CONSTRAINTS_HPP
+# define LIBIGHT_COMMON_CONSTRAINTS_HPP
+
+namespace ight {
+namespace common {
+namespace constraints {
+
+struct NonMovable {
+    NonMovable(NonMovable&&) = delete;
+    NonMovable& operator=(NonMovable&&) = delete;
+    NonMovable() {}
+};
+
+struct NonCopyable {
+    NonCopyable(NonCopyable&) = delete;
+    NonCopyable& operator=(NonCopyable&) = delete;
+    NonCopyable() {}
+};
+
+}}}  // namespaces
+#endif  // LIBIGHT_COMMON_CONSTRAINTS_HPP

--- a/src/common/libevent.h
+++ b/src/common/libevent.h
@@ -22,6 +22,8 @@
 #include <functional>
 #include <stdexcept>
 
+#include "common/constraints.hpp"
+
 struct IghtLibevent {
 
 	/*
@@ -132,7 +134,9 @@ struct IghtGlobalLibevent {
 	IghtGlobalLibevent& operator=(IghtGlobalLibevent&&) = delete;
 };
 
-class IghtEvbuffer {
+class IghtEvbuffer : public ight::common::constraints::NonCopyable,
+		public ight::common::constraints::NonMovable {
+
 	IghtLibevent *libevent = IghtGlobalLibevent::get();
 	evbuffer *evbuf = NULL;
 
@@ -157,22 +161,11 @@ class IghtEvbuffer {
 	IghtLibevent *get_libevent(void) {
 		return (libevent);
 	}
-
-	IghtEvbuffer(IghtEvbuffer&) = delete;
-	IghtEvbuffer& operator=(IghtEvbuffer&) = delete;
-
-	IghtEvbuffer(IghtEvbuffer&& other) {
-		std::swap(evbuf, other.evbuf);
-		std::swap(libevent, other.libevent);
-	}
-	IghtEvbuffer& operator=(IghtEvbuffer&& other) {
-		std::swap(evbuf, other.evbuf);
-		std::swap(libevent, other.libevent);
-		return (*this);
-	}
 };
 
-class IghtBuffereventSocket {
+class IghtBuffereventSocket : public ight::common::constraints::NonCopyable,
+		public ight::common::constraints::NonMovable {
+
 	IghtLibevent *libevent = IghtGlobalLibevent::get();
 	bufferevent *bev = NULL;
 
@@ -204,19 +197,6 @@ class IghtBuffereventSocket {
 
 	IghtLibevent *get_libevent(void) {
 		return (libevent);
-	}
-
-	IghtBuffereventSocket(IghtBuffereventSocket&) = delete;
-	IghtBuffereventSocket& operator=(IghtBuffereventSocket&) = delete;
-
-	IghtBuffereventSocket(IghtBuffereventSocket&& other) {
-		std::swap(libevent, other.libevent);
-		std::swap(bev, other.bev);
-	}
-	IghtBuffereventSocket& operator=(IghtBuffereventSocket&& other) {
-		std::swap(libevent, other.libevent);
-		std::swap(bev, other.bev);
-		return (*this);
 	}
 };
 

--- a/src/common/pointer.hpp
+++ b/src/common/pointer.hpp
@@ -1,0 +1,38 @@
+/*-
+ * This file is part of Libight <https://libight.github.io/>.
+ *
+ * Libight is free software. See AUTHORS and LICENSE for more
+ * information on the copying conditions.
+ */
+
+#ifndef LIBIGHT_COMMON_POINTER_HPP
+# define LIBIGHT_COMMON_POINTER_HPP
+
+#include <memory>
+#include <stdexcept>
+
+namespace ight {
+namespace common {
+namespace pointer {
+
+template<typename T> class SharedPointer : public std::shared_ptr<T> {
+    using std::shared_ptr<T>::shared_ptr;
+
+public:
+    T *operator->() {
+        if (this->get() == nullptr) {
+            throw std::runtime_error("null pointer");
+        }
+        return std::shared_ptr<T>::operator->();
+    }
+
+    typename std::add_lvalue_reference<T>::type operator*() {
+        if (this->get() == nullptr) {
+            throw std::runtime_error("null pointer");
+        }
+        return std::shared_ptr<T>::operator*();
+    }
+};
+
+}}}  // namespaces
+#endif  // LIBIGHT_COMMON_POINTER_HPP

--- a/src/common/poller.h
+++ b/src/common/poller.h
@@ -8,6 +8,7 @@
 #ifndef LIBIGHT_POLLER_H
 # define LIBIGHT_POLLER_H
 
+#include "common/constraints.hpp"
 #include "common/libevent.h"
 
 #include <functional>
@@ -57,7 +58,8 @@ class IghtDelayedCall {
 	}
 };
 
-class IghtPoller {
+class IghtPoller : public ight::common::constraints::NonCopyable,
+		public ight::common::constraints::NonMovable {
 
 	event_base *base;
 	evdns_base *dnsbase;
@@ -93,14 +95,6 @@ class IghtPoller {
 	void loop(void);
 
 	void break_loop(void);
-
-	/*
-	 * No copy and no move.
-	 */
-	IghtPoller(const IghtPoller&) = delete;
-	IghtPoller& operator=(const IghtPoller& other) = delete;
-	IghtPoller(const IghtPoller&&) = delete;
-	IghtPoller& operator=(const IghtPoller&& other) = delete;
 };
 
 struct IghtGlobalPoller {

--- a/src/common/poller.h
+++ b/src/common/poller.h
@@ -98,20 +98,10 @@ class IghtPoller : public ight::common::constraints::NonCopyable,
 };
 
 struct IghtGlobalPoller {
-
-	IghtGlobalPoller(void) {
-		/* nothing */
-	}
-
 	static IghtPoller *get(void) {
 		static IghtPoller singleton;
 		return (&singleton);
 	}
-
-	IghtGlobalPoller(IghtGlobalPoller&) = delete;
-	IghtGlobalPoller& operator=(IghtGlobalPoller&) = delete;
-	IghtGlobalPoller(IghtGlobalPoller&&) = delete;
-	IghtGlobalPoller& operator=(IghtGlobalPoller&&) = delete;
 };
 
 /*

--- a/src/common/poller.h
+++ b/src/common/poller.h
@@ -13,11 +13,13 @@
 
 #include <functional>
 
-class IghtDelayedCall {
+class IghtDelayedCall : public ight::common::constraints::NonCopyable,
+		public ight::common::constraints::NonMovable {
 
 	/*
-	 * The function must be a pointer and cannot be an object, because
-	 * we need to pass a stable pointer to event_new().
+	 * A previous implementation of this class required `func` to
+	 * be a pointer. The current implementation does not. So we can
+	 * rewrite the code to use an object rather than a pointer.
 	 */
 	std::function<void(void)> *func = NULL;
 	event *evp = NULL;
@@ -27,35 +29,9 @@ class IghtDelayedCall {
 	static void dispatch(evutil_socket_t, short, void *);
 
     public:
-	IghtDelayedCall(void) {
-		/* nothing */
-	}
-
 	IghtDelayedCall(double, std::function<void(void)>&&,
 	    IghtLibevent *libevent = NULL, event_base *evbase = NULL);
 	~IghtDelayedCall(void);
-
-	/*
-	 * It does not have sense to make a copy of this class, since we
-	 * don't want to manage/refcount multiple copies of `evp`.
-	 */
-	IghtDelayedCall(const IghtDelayedCall&) = delete;
-	IghtDelayedCall& operator=(const IghtDelayedCall& other) = delete;
-
-	/*
-	 * Enable move semantic.
-	 */
-	IghtDelayedCall(IghtDelayedCall&& d) {
-		std::swap(this->libevent, d.libevent);
-		std::swap(this->evp, d.evp);
-		std::swap(this->func, d.func);
-	}
-	IghtDelayedCall& operator=(IghtDelayedCall&& d) {
-		std::swap(this->libevent, d.libevent);
-		std::swap(this->evp, d.evp);
-		std::swap(this->func, d.func);
-		return (*this);
-	}
 };
 
 class IghtPoller : public ight::common::constraints::NonCopyable,

--- a/src/common/stringvector.h
+++ b/src/common/stringvector.h
@@ -9,6 +9,8 @@
 # define LIBIGHT_STRINGVECTOR_H
 # ifdef __cplusplus
 
+#include "common/constraints.hpp"
+
 /*-
  * StringVector
  *   A vector of strings that is used to implement the resolver.
@@ -16,7 +18,8 @@
 
 class IghtPoller;
 
-struct IghtStringVector {
+struct IghtStringVector : public ight::common::constraints::NonCopyable,
+		public ight::common::constraints::NonMovable {
     private: 
 	char **base;
 	size_t count;

--- a/src/net/connection.cpp
+++ b/src/net/connection.cpp
@@ -177,8 +177,8 @@ IghtConnectionState::IghtConnectionState(const char *family, const char *address
 	    this->handle_event, this);
 
 	if (!ight_socket_valid(filenum))
-		this->start_connect = IghtDelayedCall(0.0, std::bind(
-		    this->resolve, this));
+		this->start_connect = std::make_shared<IghtDelayedCall>(0.0,
+		    std::bind(this->resolve, this));
 	else
 		this->filedesc = filenum;	/* Own the socket on success */
 }

--- a/src/net/connection.h
+++ b/src/net/connection.h
@@ -10,6 +10,7 @@
 # ifdef __cplusplus
 
 #include "common/error.h"
+#include "common/pointer.hpp"
 #include "common/poller.h"
 #include "common/utils.hpp"
 
@@ -36,7 +37,7 @@ class IghtConnectionState {
 	IghtStringVector *pflist = NULL;
 	unsigned int must_resolve_ipv4 = 0;
 	unsigned int must_resolve_ipv6 = 0;
-	IghtDelayedCall start_connect;
+	ight::common::pointer::SharedPointer<IghtDelayedCall> start_connect;
 
 	// Private destructor because destruction may be delayed
 	~IghtConnectionState(void);

--- a/src/ooni/net_test.cpp
+++ b/src/ooni/net_test.cpp
@@ -145,7 +145,7 @@ NetTest::teardown() {
 void
 NetTest::main(ight::common::Settings,
               std::function<void(ReportEntry)>&& cb) {
-  delayed_call = IghtDelayedCall(1.25, [=](void) {
+  delayed_call = std::make_shared<IghtDelayedCall>(1.25, [=](void) {
     ReportEntry entry;
     cb(entry);
   });
@@ -154,7 +154,7 @@ NetTest::main(ight::common::Settings,
 void
 NetTest::main(std::string, ight::common::Settings,
               std::function<void(ReportEntry)>&& cb) {
-  delayed_call = IghtDelayedCall(1.25, [=](void) {
+  delayed_call = std::make_shared<IghtDelayedCall>(1.25, [=](void) {
     ReportEntry entry;
     cb(entry);
   });

--- a/src/ooni/net_test.hpp
+++ b/src/ooni/net_test.hpp
@@ -6,6 +6,8 @@
 #include <fstream>
 
 #include "report/file.hpp"
+
+#include "common/pointer.hpp"
 #include "common/poller.h"
 #include "common/settings.hpp"
 #include "common/log.h"
@@ -13,6 +15,8 @@
 namespace ight {
 namespace ooni {
 namespace net_test {
+
+using namespace ight::common::pointer;
 
 class InputGenerator {
 
@@ -66,7 +70,7 @@ class NetTest {
   std::string input_filepath;
   FileReporter file_report;
 
-  IghtDelayedCall delayed_call;
+  SharedPointer<IghtDelayedCall> delayed_call;
 
   void run_next_measurement(const std::function<void()>&& cb);
 

--- a/test/common/bufferevent.cpp
+++ b/test/common/bufferevent.cpp
@@ -30,7 +30,7 @@ TEST_CASE("Constructors") {
     };
 
     {
-      auto b = IghtBuffereventSocket(&libevent);
+      IghtBuffereventSocket b(&libevent);
     }
     
     REQUIRE(calls == 0);
@@ -38,7 +38,7 @@ TEST_CASE("Constructors") {
 
   SECTION("An exception should be raised if bufferevent is NULL") {
     REQUIRE_THROWS_AS([](void) {
-        auto b = IghtBuffereventSocket();
+        IghtBuffereventSocket b;
         auto p = (bufferevent *) b;
         (void) p;
         return;
@@ -61,7 +61,7 @@ TEST_CASE("Constructors") {
 
     {
       auto poller = IghtGlobalPoller::get();
-      auto b = IghtBuffereventSocket(poller->get_event_base(),
+      IghtBuffereventSocket b(poller->get_event_base(),
           -1, 0, &libevent);
     }
 
@@ -96,61 +96,10 @@ TEST_CASE("IghtBufferEventSocket operations") {
     };
 
     auto poller = IghtGlobalPoller::get();
-    auto b = IghtBuffereventSocket(poller->get_event_base(), -1, 0,
+    IghtBuffereventSocket b(poller->get_event_base(), -1, 0,
         &libevent);
 
     REQUIRE(underlying == (bufferevent *) b);
   }
   
-  SECTION("Move constructor") {
-    auto libevent = IghtLibevent();
-    auto underlying = (bufferevent *) NULL;
-
-    libevent.bufferevent_socket_new = [&](event_base *b,
-        evutil_socket_t s, int o) {
-      return (underlying = ::bufferevent_socket_new(b, s, o));
-    };
-
-    auto poller = IghtGlobalPoller::get();
-    auto b1 = IghtBuffereventSocket(poller->get_event_base(),
-        0, 0, &libevent);
-    auto b2 = IghtBuffereventSocket(std::move(b1));
-
-    REQUIRE(b2.get_libevent() == &libevent);
-    REQUIRE(underlying == (bufferevent *) b2);
-    REQUIRE(b1.get_libevent() == IghtGlobalLibevent::get());
-
-    REQUIRE_THROWS_AS([&](void){
-      auto ppp = (bufferevent *) b1;
-      (void) ppp;
-    }(), std::runtime_error);
-
-  }
-
-  SECTION("Move assignment") {
-    auto libevent1 = IghtLibevent();
-    auto underlying = (bufferevent *) NULL;
-
-    libevent1.bufferevent_socket_new = [&](event_base *b,
-        evutil_socket_t s, int o) {
-      return (underlying = ::bufferevent_socket_new(b, s, o));
-    };
-
-    auto poller = IghtGlobalPoller::get();
-    auto b1 = IghtBuffereventSocket(poller->get_event_base(),
-        0, 0, &libevent1);
-    auto libevent2 = IghtLibevent();
-    auto b2 = IghtBuffereventSocket(&libevent2);
-    b2 = std::move(b1);
-
-    REQUIRE(b2.get_libevent() == &libevent1);
-    REQUIRE(underlying == (bufferevent *) b2);
-    REQUIRE(b1.get_libevent() == &libevent2);
-
-    REQUIRE_THROWS_AS([&](void){
-      auto ppp = (bufferevent *) b1;
-      (void) ppp;
-    }(), std::runtime_error);
-
-  }
 }

--- a/test/common/delayed_call.cpp
+++ b/test/common/delayed_call.cpp
@@ -12,9 +12,10 @@
 #define CATCH_CONFIG_MAIN
 #include "src/ext/Catch/single_include/catch.hpp"
 
+#include "common/pointer.hpp"
 #include "common/poller.h"
 
-#include <iostream> 
+using namespace ight::common::pointer;
 
 TEST_CASE("Bad allocations triggers a failure ") {
 	IghtLibevent libevent;
@@ -43,76 +44,18 @@ TEST_CASE("Check that the event callbacks are fired") {
 	IghtLibevent libevent;
 
   SECTION("event_free must be called") {
-	  auto event_free_called = false;
+    auto event_free_called = false;
 
     libevent.event_free = [&event_free_called](event *evp) {
       event_free_called = true;
       ::event_free(evp);
     };
 
-		IghtDelayedCall(0.0, [](void) { }, &libevent);
+    IghtDelayedCall(0.0, [](void) { }, &libevent);
 
     REQUIRE(event_free_called == true);
   }
 }
-
-
-TEST_CASE("Move semantics must preserve libevent free calling") {
-
-  SECTION("Must preserve libevent free calling") {
-    auto event_free_called = 0;
-    IghtLibevent libevent;
-
-    libevent.event_free = [&event_free_called](event *evp) {
-      ++event_free_called;
-      ::event_free(evp);
-    };
-
-    auto d1 = IghtDelayedCall(0.0, [](void) { }, &libevent);
-    {
-      // Move constructor
-      IghtDelayedCall d2(std::move(d1));
-    }
-    REQUIRE(event_free_called == 1);
-
-    auto d3 = IghtDelayedCall(0.0, [](void) { }, &libevent);
-    {
-      // Move assignment
-      auto d4 = IghtDelayedCall();
-      d4 = std::move(d3);
-    }
-    REQUIRE(event_free_called == 2);
-  }
-  
-  SECTION("Replace a delayed call with a new one") {
-    auto called = false;
-    auto not_called = false;
-
-    //
-    // Register a first delayed call (which will be overriden
-    // later) to ensure that move semantic works.
-    //
-    auto d2 = IghtDelayedCall(0.0, [&](void) {
-        not_called = true;
-    });
-
-    //
-    // Replace the delayed call (which should clear the previous
-    // delayed call contained by d2, if any) with a new one, using
-    // the move semantic.
-    //
-    d2 = IghtDelayedCall(0.0, [&](void) {
-        called = true;
-        ight_break_loop();
-	  });
-
-    ight_loop();
-
-    REQUIRE(called == true);
-    REQUIRE(not_called == false);
-  }
-}
-
 
 TEST_CASE("Destructor cancels delayed calls") {
 
@@ -124,13 +67,13 @@ TEST_CASE("Destructor cancels delayed calls") {
     // at any time by peer.
     //
     struct X {
-      IghtDelayedCall d;
+      SharedPointer<IghtDelayedCall> d;
     };
 
     auto called = false;
     auto x = new X();
-    x->d = IghtDelayedCall(0.0, [&](void) {
-        called = true;
+    x->d = std::make_shared<IghtDelayedCall>(0.0, [&](void) {
+      called = true;
     });
     delete (x);
     REQUIRE(called == false);
@@ -150,9 +93,9 @@ TEST_CASE("Destructor cancels delayed calls") {
     //
     auto called = false; 
     auto d1 = new IghtDelayedCall(0.25, [&](void) {
-        called = true;
+      called = true;
     });
-    auto d2 = IghtDelayedCall(0.249, [&](void) {
+    IghtDelayedCall d2(0.249, [&](void) {
       delete (d1);
     });
     d1 = NULL;  /* Clear the pointer, just in case */
@@ -167,7 +110,7 @@ TEST_CASE("Delayed call construction") {
     // Make sure that an empty delayed call is successfully
     // destroyed (no segfault) when we leave the scope.
     //
-    auto d1 = IghtDelayedCall();
+    IghtDelayedCall d1{0.0, [](){}};
   }
 
   SECTION("Create a delayed call with empty std::function") {
@@ -175,9 +118,10 @@ TEST_CASE("Delayed call construction") {
     // Make sure that we don't raise an exception in the libevent
     // callback, when we're passed an empty std::function.
     //
-    auto d3 = IghtDelayedCall(0.5, std::function<void(void)>());
+    IghtDelayedCall d3(0.0, std::function<void(void)>());
+    IghtDelayedCall d4(0.1, []() {
+        ight_break_loop();
+    });
+    ight_loop();
   }
-  
 }
-
-

--- a/test/common/delayed_call.cpp
+++ b/test/common/delayed_call.cpp
@@ -98,6 +98,10 @@ TEST_CASE("Destructor cancels delayed calls") {
     IghtDelayedCall d2(0.249, [&](void) {
       delete (d1);
     });
+    IghtDelayedCall d3(0.33, []() {
+      ight_break_loop();
+    });
+    ight_loop();
     d1 = NULL;  /* Clear the pointer, just in case */
     REQUIRE(called == false);
   }

--- a/test/common/poller.cpp
+++ b/test/common/poller.cpp
@@ -258,7 +258,7 @@ TEST_CASE("SIGINT is correctly handled on Unix") {
     SECTION("SIGINT is correctly handled after the handler is set") {
 	IghtPoller poller;
 
-	auto d = IghtDelayedCall(0.01, [](void) {
+	IghtDelayedCall d(0.01, [](void) {
 	    raise(SIGINT);
 	}, NULL, poller.get_event_base());
 
@@ -276,7 +276,7 @@ TEST_CASE("SIGINT is correctly handled on Unix") {
 
 	if (pid == 0) {
 		IghtPoller poller;
-		auto d = IghtDelayedCall(0.01, [](void) {
+		IghtDelayedCall d(0.01, [](void) {
 			raise(SIGINT);
 		}, NULL, poller.get_event_base());
 		/*

--- a/test/net/buffer.cpp
+++ b/test/net/buffer.cpp
@@ -21,7 +21,7 @@ TEST_CASE("The constructor works correctly", "[IghtBuffer]") {
 
 TEST_CASE("Insertion/extraction work correctly for evbuffer") {
 
-	auto buff = IghtBuffer();
+	IghtBuffer buff;
 	IghtEvbuffer source;
 	IghtEvbuffer dest;
 	auto sa = std::string(65536, 'A');

--- a/test/net/buffer.cpp
+++ b/test/net/buffer.cpp
@@ -22,8 +22,8 @@ TEST_CASE("The constructor works correctly", "[IghtBuffer]") {
 TEST_CASE("Insertion/extraction work correctly for evbuffer") {
 
 	auto buff = IghtBuffer();
-	auto source = IghtEvbuffer();
-	auto dest = IghtEvbuffer();
+	IghtEvbuffer source;
+	IghtEvbuffer dest;
 	auto sa = std::string(65536, 'A');
 	auto r = std::string();
 
@@ -104,7 +104,7 @@ TEST_CASE("Foreach works correctly", "[IghtBuffer]") {
 	 * Initialize the source evbuffer.
 	 */
 
-	auto evbuf = IghtEvbuffer();
+	IghtEvbuffer evbuf;
 
 	auto sa = std::string(512, 'A');
 	auto sb = std::string(512, 'B');

--- a/test/protocols/dns.cpp
+++ b/test/protocols/dns.cpp
@@ -616,7 +616,7 @@ TEST_CASE("The system resolver works as expected") {
 
     auto failed = false;
 
-    auto d = IghtDelayedCall(10.0, [&](void) {
+    IghtDelayedCall d(10.0, [&](void) {
         failed = true;
         ight_break_loop();
     });
@@ -997,7 +997,7 @@ TEST_CASE("The default custom resolver works as expected") {
 
     auto failed = false;
 
-    auto d = IghtDelayedCall(10.0, [&](void) {
+    IghtDelayedCall d(10.0, [&](void) {
         failed = true;
         ight_break_loop();
     });
@@ -1071,7 +1071,7 @@ TEST_CASE("A specific custom resolver works as expected") {
 
     auto failed = false;
 
-    auto d = IghtDelayedCall(10.0, [&](void) {
+    IghtDelayedCall d(10.0, [&](void) {
         failed = true;
         ight_break_loop();
     });
@@ -1160,13 +1160,13 @@ TEST_CASE("If the resolver dies the requests are aborted") {
         ight_break_loop();
     });
 
-    auto d1 = IghtDelayedCall(0.1, [&](void) {
+    IghtDelayedCall d1(0.1, [&](void) {
         delete reso;  // Destroy the resolver and see what happens..
                       // in theory the request callback *should* be called
     });
 
     auto failed = false;
-    auto d2 = IghtDelayedCall(1.0, [&](void) {
+    IghtDelayedCall d2(1.0, [&](void) {
         // This *should not* be called, since the request callback
         // shold be called before than this one.
         failed = true;
@@ -1208,7 +1208,7 @@ TEST_CASE("A request to a nonexistent server times out") {
     });
 
     auto failed = false;
-    auto d = IghtDelayedCall(10.0, [&](void) {
+    IghtDelayedCall d(10.0, [&](void) {
         failed = true;
         ight_break_loop();
     });
@@ -1271,7 +1271,7 @@ TEST_CASE("It is safe to cancel requests in flight") {
             ight_warn("- break_loop");
             ight_break_loop();
         }, reso.get_evdns_base());
-        auto d = IghtDelayedCall(avgrtt, [&](void) {
+        IghtDelayedCall d(avgrtt, [&](void) {
             ight_warn("- cancel");
             r->cancel();
             ight_break_loop();


### PR DESCRIPTION
I was using move semantic in an error prone way. Hand-writing move constructor and move-assignment operator leads to errors when one forgets to update them *and* a new field is added (see #61 and in particular 78fc5d122ec and 5c221b47278).

Also, when there are lambdas bound to an object's `this`, either the object must be created on the heap or the lambdas must be recreated after each move (see again #61, in particular 097d1b5a3a8a and 72ea0117539). In this case the problem is that making an object movable encourages one to create it on the stack, which is exactly what should not happen.

Thinking a bit more on move semantic, I've come to the conclusion that  we should rely on the compiler's move semantic for simpler objects. As regards complex objects, we should make them non copyable and non movable; we should allocate such complex objects on the heap; and we should manage such complex objects lifecycle using smart pointers (see #62).

This pull requests starts making sure that move semantic is not used in an error-prone way and replaces its usage with safer and simpler patterns. It covers the files below the `src/common` folder. I have patches for other parts of the tree.