### PR TITLE
Fix dns move semantic

### DIFF
--- a/src/ooni/dns_test.cpp
+++ b/src/ooni/dns_test.cpp
@@ -1,13 +1,15 @@
 #include "ooni/dns_test.hpp"
 
 using namespace ight::ooni::dns_test;
+using namespace ight::protocols::dns;
+using namespace ight::common;
 
 void
 DNSTest::query(QueryType query_type, QueryClass /*query_class*/,
                std::string query_name, std::string nameserver,
                std::function<void(ight::protocols::dns::Response&&)>&& cb)
 {
-    resolver = ight::protocols::dns::Resolver({
+    resolver = std::make_shared<Resolver>(Settings{
         {"nameserver", nameserver},
         {"attempts", "1"},
     }, libevent);
@@ -25,7 +27,7 @@ DNSTest::query(QueryType query_type, QueryClass /*query_class*/,
     } else {
         throw UnsupportedQueryType("Currently we only support A");
     }
-    resolver.request(
+    resolver->request(
         query, query_name, 
         [=](ight::protocols::dns::Response&& response) {
             ight_debug("Got a response!");

--- a/src/ooni/dns_test.hpp
+++ b/src/ooni/dns_test.hpp
@@ -1,12 +1,16 @@
 #ifndef LIBIGHT_OONI_DNS_TEST_HPP
 # define LIBIGHT_OONI_DNS_TEST_HPP
 
+#include "common/pointer.hpp"
+
 #include "protocols/dns.hpp"
 #include "ooni/net_test.hpp"
 
 namespace ight {
 namespace ooni {
 namespace dns_test {
+
+using namespace ight::common::pointer;
 
 struct UnsupportedQueryType : public std::runtime_error {
   using std::runtime_error::runtime_error;
@@ -19,7 +23,7 @@ enum class QueryClass {IN, CS, CH, HS};
 class DNSTest : public net_test::NetTest {
     using net_test::NetTest::NetTest;
 
-    protocols::dns::Resolver resolver;
+    SharedPointer<protocols::dns::Resolver> resolver;
 
 public:
     DNSTest(std::string input_filepath_, ight::common::Settings options_) : 

--- a/src/protocols/dns.hpp
+++ b/src/protocols/dns.hpp
@@ -13,6 +13,7 @@
 //
 
 #include "common/log.h"
+#include "common/pointer.hpp"
 #include "common/poller.h"
 #include "common/settings.hpp"
 
@@ -26,7 +27,7 @@ namespace ight {
 namespace protocols {
 namespace dns {
 
-class RequestImpl;  // Defined in net/dns.cpp
+using namespace ight::common::pointer;
 
 /*!
  * \brief DNS response.
@@ -191,7 +192,7 @@ public:
 class Request {
 
 protected:
-    RequestImpl *impl = nullptr;
+    SharedPointer<bool> cancelled;
 
 public:
 
@@ -226,15 +227,19 @@ public:
 
     /*!
      * \brief Deleted copy constructor.
-     * \remark We cannot copy this object because it contains a pointer
-     *         to an object allocated with new that must not be shared.
+     * \remark The original implementation of Request could not be
+     *         shared because it contained a raw pointer. This second
+     *         implementation retains the same behavior even though
+     *         now there are no technical restrictions to do so.
      */
     Request(Request& /*other*/) = delete;
 
     /*!
      * \brief Deleted assignment constructor.
-     * \remark We cannot copy this object because it contains a pointer
-     *         to an object allocated with new that must not be shared.
+     * \remark The original implementation of Request could not be
+     *         shared because it contained a raw pointer. This second
+     *         implementation retains the same behavior even though
+     *         now there are no technical restrictions to do so.
      */
     Request& operator=(Request& /*other*/) = delete;
 
@@ -242,14 +247,14 @@ public:
      * \brief Move constructor.
      */
     Request(Request&& other) {
-        std::swap(impl, other.impl);
+        std::swap(cancelled, other.cancelled);
     }
 
     /*!
      * \brief Move assignment.
      */
     Request& operator=(Request&& other) {
-        std::swap(impl, other.impl);
+        std::swap(cancelled, other.cancelled);
         return *this;
     }
 

--- a/src/protocols/dns.hpp
+++ b/src/protocols/dns.hpp
@@ -214,38 +214,10 @@ public:
             std::function<void(Response&&)>&& func, evdns_base *dnsb = NULL,
             IghtLibevent *libevent = NULL);
 
-    /*!
-     * \brief Deleted copy constructor.
-     * \remark The original implementation of Request could not be
-     *         shared because it contained a raw pointer. This second
-     *         implementation retains the same behavior even though
-     *         now there are no technical restrictions to do so.
-     */
-    Request(Request& /*other*/) = delete;
-
-    /*!
-     * \brief Deleted assignment constructor.
-     * \remark The original implementation of Request could not be
-     *         shared because it contained a raw pointer. This second
-     *         implementation retains the same behavior even though
-     *         now there are no technical restrictions to do so.
-     */
-    Request& operator=(Request& /*other*/) = delete;
-
-    /*!
-     * \brief Move constructor.
-     */
-    Request(Request&& other) {
-        std::swap(cancelled, other.cancelled);
-    }
-
-    /*!
-     * \brief Move assignment.
-     */
-    Request& operator=(Request&& other) {
-        std::swap(cancelled, other.cancelled);
-        return *this;
-    }
+    Request(Request&) = default;
+    Request& operator=(Request&) = default;
+    Request(Request&&) = default;
+    Request& operator=(Request&&) = default;
 
     /*!
      * \brief Cancel the pending Request.

--- a/src/protocols/dns.hpp
+++ b/src/protocols/dns.hpp
@@ -12,6 +12,7 @@
 // DNS client functionality
 //
 
+#include "common/constraints.hpp"
 #include "common/log.h"
 #include "common/pointer.hpp"
 #include "common/poller.h"
@@ -27,6 +28,7 @@ namespace ight {
 namespace protocols {
 namespace dns {
 
+using namespace ight::common::constraints;
 using namespace ight::common::pointer;
 
 /*!
@@ -290,7 +292,7 @@ public:
  * destroyed when the resolver is destroyed (in particular, the callback
  * will be invoked with evdns code equal to DNS_ERR_SHUTDOWN).
  */
-class Resolver {
+class Resolver : public NonCopyable, public NonMovable {
 
     void cleanup(void);
 
@@ -356,41 +358,6 @@ public:
      */
     ~Resolver(void) {
         cleanup();
-    }
-
-    /*!
-     * \brief Deleted copy constructor.
-     * \remark We cannot copy this object because it contains a pointer
-     *         to an object allocated with new that must not be shared.
-     */
-    Resolver(Resolver& /*other*/) = delete;
-
-    /*!
-     * \brief Deleted assignment constructor.
-     * \remark We cannot copy this object because it contains a pointer
-     *         to an object allocated with new that must not be shared.
-     */
-    Resolver& operator=(Resolver& /*other*/) = delete;
-
-    /*!
-     * \brief Move constructor.
-     */
-    Resolver(Resolver&& other) {
-        std::swap(settings, other.settings);
-        std::swap(libevent, other.libevent);
-        std::swap(poller, other.poller);
-        std::swap(base, other.base);
-    }
-
-    /*!
-     * \brief Move assignment.
-     */
-    Resolver& operator=(Resolver&& other) {
-        std::swap(settings, other.settings);
-        std::swap(libevent, other.libevent);
-        std::swap(poller, other.poller);
-        std::swap(base, other.base);
-        return *this;
     }
 };
 

--- a/src/protocols/dns.hpp
+++ b/src/protocols/dns.hpp
@@ -47,23 +47,10 @@ protected:
     std::vector<std::string> results;
 
 public:
-    Response(Response& /*other*/) = delete;
-    Response& operator=(Response& /*other*/) = delete;
-
-    Response(Response&& other) {
-        std::swap(code, other.code);
-        std::swap(rtt, other.rtt);
-        std::swap(ttl, other.ttl);
-        std::swap(results, other.results);
-    }
-
-    Response& operator=(Response&& other) {
-        std::swap(code, other.code);
-        std::swap(rtt, other.rtt);
-        std::swap(ttl, other.ttl);
-        std::swap(results, other.results);
-        return *this;
-    }
+    Response(Response&) = default;
+    Response& operator=(Response&) = default;
+    Response(Response&&) = default;
+    Response& operator=(Response&&) = default;
 
     /*!
      * \brief Constructs an empty DNS response object.

--- a/test/protocols/dns.cpp
+++ b/test/protocols/dns.cpp
@@ -869,100 +869,14 @@ TEST_CASE("Resolver: evdns_base_set_option failure is correctly handled") {
 }
 
 TEST_CASE("Resolver::get_evdns_base() is idempotent") {
-    auto reso = Resolver();
+    Resolver reso;
     REQUIRE(reso.get_evdns_base() == reso.get_evdns_base());
-}
-
-struct TransparentResolver : public Resolver {
-    using Resolver::Resolver;
-
-    ight::common::Settings get_settings_() {
-        return settings;
-    }
-
-    IghtLibevent *get_libevent_() {
-        return libevent;
-    }
-
-    IghtPoller *get_poller_() {
-        return poller;
-    }
-
-    evdns_base *get_evdns_base_() {
-        return base;
-    }
-
-};
-
-TEST_CASE("Move semantic works for resolver") {
-
-    IghtLibevent libevent;
-    IghtPoller poller;
-
-    SECTION("Move assignment") {
-
-        TransparentResolver r1;
-
-        REQUIRE(r1.get_settings_().size() == 0);
-        REQUIRE(r1.get_libevent_() == IghtGlobalLibevent::get());
-        REQUIRE(r1.get_poller_() == ight_get_global_poller());
-        REQUIRE(r1.get_evdns_base_() == nullptr);
-
-        TransparentResolver r2{{
-            {"nameserver", "8.8.8.8"},
-        }, &libevent, &poller};
-
-        (void) r2.get_evdns_base();  /* Trigger lazy alloc */
-
-        REQUIRE(r2.get_settings_().size() == 1);
-        REQUIRE(r2.get_settings_()["nameserver"] == "8.8.8.8");
-        REQUIRE(r2.get_libevent_() == &libevent);
-        REQUIRE(r2.get_poller_() == &poller);
-        REQUIRE(r2.get_evdns_base_() != nullptr);
-
-        r1 = std::move(r2);  /* Move assignment */
-
-        REQUIRE(r1.get_settings_().size() == 1);
-        REQUIRE(r1.get_settings_()["nameserver"] == "8.8.8.8");
-        REQUIRE(r1.get_libevent_() == &libevent);
-        REQUIRE(r1.get_poller_() == &poller);
-        REQUIRE(r1.get_evdns_base_() != nullptr);
-
-        REQUIRE(r2.get_settings_().size() == 0);
-        REQUIRE(r2.get_libevent_() == IghtGlobalLibevent::get());
-        REQUIRE(r2.get_poller_() == ight_get_global_poller());
-        REQUIRE(r2.get_evdns_base_() == nullptr);
-    }
-
-    SECTION("Move constructor") {
-
-        TransparentResolver r2{{
-            {"nameserver", "8.8.8.8"},
-        }, &libevent, &poller};
-
-        (void) r2.get_evdns_base();  /* Trigger lazy alloc */
-
-        [&libevent, &poller](TransparentResolver r1) {
-            REQUIRE(r1.get_settings_().size() == 1);
-            REQUIRE(r1.get_settings_()["nameserver"] == "8.8.8.8");
-            REQUIRE(r1.get_libevent_() == &libevent);
-            REQUIRE(r1.get_poller_() == &poller);
-            REQUIRE(r1.get_evdns_base_() != nullptr);
-
-        }(std::move(r2));  /* Move constructor */
-
-        REQUIRE(r2.get_settings_().size() == 0);
-        REQUIRE(r2.get_libevent_() == IghtGlobalLibevent::get());
-        REQUIRE(r2.get_poller_() == ight_get_global_poller());
-        REQUIRE(r2.get_evdns_base_() == nullptr);
-    }
-
 }
 
 TEST_CASE("We can override the default timeout") {
 
     // I need to remember to never run a DNS on that machine :^)
-    auto reso = Resolver({
+    Resolver reso({
         {"nameserver", "130.192.91.231"},
         {"attempts", "1"},
         {"timeout", "0.5"}
@@ -991,7 +905,7 @@ TEST_CASE("We can override the default timeout") {
 TEST_CASE("We can override the default number of tries") {
 
     // I need to remember to never run a DNS on that machine :^)
-    auto reso = Resolver({
+    Resolver reso({
         {"nameserver", "130.192.91.231"},
         {"attempts", "2"},
         {"timeout", "0.5"},
@@ -1035,7 +949,7 @@ TEST_CASE("The default custom resolver works as expected") {
         ight_break_loop();
     });
 
-    auto reso = Resolver();
+    Resolver reso;
 
     reso.request("A", "www.neubot.org", [&](Response&& response) {
         REQUIRE(response.get_reply_authoritative() == "unknown");
@@ -1109,7 +1023,7 @@ TEST_CASE("A specific custom resolver works as expected") {
         ight_break_loop();
     });
 
-    auto reso = Resolver(ight::common::Settings({
+    Resolver reso(ight::common::Settings({
         {"nameserver", "8.8.4.4"},
     }));
 
@@ -1226,7 +1140,7 @@ TEST_CASE("A request to a nonexistent server times out") {
     //
 
     // I need to remember to never run a DNS on that machine :^)
-    auto reso = Resolver({
+    Resolver reso({
         {"nameserver", "130.192.91.231"},
         {"attempts", "1"},
     });
@@ -1267,7 +1181,7 @@ TEST_CASE("It is safe to cancel requests in flight") {
     // privately run this test repeating it for about one minute.
     //
 
-    auto reso = Resolver({
+    Resolver reso({
         {"nameserver", "8.8.8.8"},
         {"attempts", "1"},
     });
@@ -1327,7 +1241,7 @@ TEST_CASE("It is safe to cancel requests in flight") {
 
 /*
 TEST_CASE("Make sure we can override host and number of tries") {
-    auto reso = Resolver({
+    Resolver reso({
         {"nameserver", "127.0.0.1:5353"},
         {"attempts", "2"},
     });

--- a/test/protocols/dns.cpp
+++ b/test/protocols/dns.cpp
@@ -708,7 +708,7 @@ TEST_CASE("It is safe to clear a request in its own callback") {
     }
     auto d = SafeToDeleteRequestInItsOwnCallback();
     auto called = 0;
-    auto watchdog = IghtDelayedCall(5.0, [&called]() {
+    IghtDelayedCall watchdog(5.0, [&called]() {
         ++called;
         ight_break_loop();
     });

--- a/test/protocols/dns.cpp
+++ b/test/protocols/dns.cpp
@@ -318,10 +318,14 @@ TEST_CASE("Move semantic works for response") {
         REQUIRE(r1.get_results_()[0] == "antani");
         REQUIRE(r1.get_results_()[1] == "blinda");
 
-        REQUIRE(r2.get_code_() == DNS_ERR_UNKNOWN);
-        REQUIRE(r2.get_rtt_() == 0.0);
-        REQUIRE(r2.get_ttl_() == 0);
-        REQUIRE(r2.get_results_().size() == 0);
+        //
+        // Note: move semantic is *copy* for integers and the like, which
+        // explains why everything but results is copied below.
+        //
+        REQUIRE(r2.get_code_() == DNS_ERR_NONE);  // copied
+        REQUIRE(r2.get_rtt_() == 1.0);            // copied
+        REQUIRE(r2.get_ttl_() == 32764);          // copied
+        REQUIRE(r2.get_results_().size() == 0);   // move
     }
 
     SECTION("Move constructor") {
@@ -342,10 +346,14 @@ TEST_CASE("Move semantic works for response") {
 
         }(std::move(r2));  /* Move constructor */
 
-        REQUIRE(r2.get_code_() == DNS_ERR_UNKNOWN);
-        REQUIRE(r2.get_rtt_() == 0.0);
-        REQUIRE(r2.get_ttl_() == 0);
-        REQUIRE(r2.get_results_().size() == 0);
+        //
+        // Note: move semantic is *copy* for integers and the like, which
+        // explains why everything but results is copied below.
+        //
+        REQUIRE(r2.get_code_() == DNS_ERR_NONE);  // copied
+        REQUIRE(r2.get_rtt_() == 1.0);            // copied
+        REQUIRE(r2.get_ttl_() == 32764);          // copied
+        REQUIRE(r2.get_results_().size() == 0);   // moved
     }
 
 }

--- a/test/protocols/dns.cpp
+++ b/test/protocols/dns.cpp
@@ -551,8 +551,8 @@ TEST_CASE("Request::cancel() is safe when a request is pending") {
 struct TransparentRequest : public Request {
     using Request::Request;
 
-    RequestImpl *get_impl_() {
-        return impl;
+    SharedPointer<bool> get_cancelled_() {
+        return cancelled;
     }
 };
 
@@ -562,20 +562,19 @@ TEST_CASE("Move semantic works for request") {
 
         TransparentRequest r1;
 
-        REQUIRE(r1.get_impl_() == nullptr);
+        REQUIRE_THROWS(*r1.get_cancelled_());
 
         TransparentRequest r2{"A", "www.neubot.org",
                 [](Response&&) {
             /* nothing */
         }};
-        auto p = r2.get_impl_();
-        REQUIRE(p != nullptr);
+        REQUIRE(*r2.get_cancelled_() == false);
 
         r1 = std::move(r2);  /* Move assignment */
 
-        REQUIRE(r1.get_impl_() == p);
+        REQUIRE(*r1.get_cancelled_() == false);
 
-        REQUIRE(r2.get_impl_() == nullptr);
+        REQUIRE_THROWS(*r2.get_cancelled_());
     }
 
     SECTION("Move constructor") {
@@ -583,15 +582,14 @@ TEST_CASE("Move semantic works for request") {
                 [](Response&&) {
             /* nothing */
         }};
-        auto p = r2.get_impl_();
-        REQUIRE(p != nullptr);
+        REQUIRE(*r2.get_cancelled_() == false);
 
-        [p](TransparentRequest r1) {
-            REQUIRE(r1.get_impl_() == p);
+        [](TransparentRequest r1) {
+            REQUIRE(*r1.get_cancelled_() == false);
 
         }(std::move(r2));  /* Move constructor */
 
-        REQUIRE(r2.get_impl_() == nullptr);
+        REQUIRE_THROWS(*r2.get_cancelled_());
     }
 
 }
@@ -681,6 +679,33 @@ TEST_CASE("The system resolver works as expected") {
     ight_loop();
 
     REQUIRE(!failed);
+}
+
+class SafeToDeleteRequestInItsOwnCallback {
+    Request request;
+public:
+    SafeToDeleteRequestInItsOwnCallback() {
+        request = Request("A", "nexa.polito.it", [this](Response&&) {
+            // This assignment should trigger the original request's destructor
+            request = Request("AAAA", "nexa.polito.it", [this](Response&&) {
+                ight_break_loop();
+            });
+        });
+    }
+};
+
+TEST_CASE("It is safe to clear a request in its own callback") {
+    if (ight::Network::is_down()) {
+        return;
+    }
+    auto d = SafeToDeleteRequestInItsOwnCallback();
+    auto called = 0;
+    auto watchdog = IghtDelayedCall(5.0, [&called]() {
+        ++called;
+        ight_break_loop();
+    });
+    ight_loop();
+    REQUIRE(called == 0);
 }
 
 //


### PR DESCRIPTION
Remove hand-rolled move semantic. Use compiler-provided copy and move implementation for objects that don't contain pointers to C structures and/or lambdas. Otherwise, disable copy and move and, when copy and move are needed, allocate on the heap using SharedPointer.