### PR TITLE
Fix net move semantic

### DIFF
--- a/src/net/buffer.hpp
+++ b/src/net/buffer.hpp
@@ -8,6 +8,7 @@
 #ifndef LIBIGHT_NET_BUFFER_HPP
 # define LIBIGHT_NET_BUFFER_HPP
 
+#include "common/constraints.hpp"
 #include "common/utils.hpp"
 
 #include <event2/bufferevent.h>
@@ -27,7 +28,8 @@
 #endif
 
 // Helper class for IghtBuffer (see below)
-class IghtIovec {
+class IghtIovec : public ight::common::constraints::NonCopyable,
+		public ight::common::constraints::NonMovable  {
 	evbuffer_iovec *iov = NULL;
 	size_t count = 0;
 
@@ -42,19 +44,6 @@ class IghtIovec {
 
 	~IghtIovec(void) {
 		ight_xfree(iov);
-	}
-
-	IghtIovec(IghtIovec&) = delete;
-	IghtIovec& operator=(IghtIovec&) = delete;
-
-	IghtIovec(IghtIovec&& other) {
-		std::swap(iov, other.iov);
-		std::swap(count, other.count);
-	}
-	IghtIovec& operator=(IghtIovec&& other) {
-		std::swap(iov, other.iov);
-		std::swap(count, other.count);
-		return (*this);
 	}
 
 	evbuffer_iovec *operator[](int i) {
@@ -148,7 +137,7 @@ class IghtBuffer {
 		if (required_size == 0)
 			return;
 
-		auto iov = IghtIovec(required_size);
+		IghtIovec iov(required_size);
 		auto used = evbuffer_peek(evbuf, -1, NULL,
 		    iov.get_base(), iov.get_length());
 		if (used != required_size)
@@ -290,7 +279,7 @@ class IghtBuffer {
 		if (count == 0)
 			return;
 
-		auto iov = IghtIovec(IOV_MAX);
+		IghtIovec iov(IOV_MAX);
 		int i, n_extents;
 
 		n_extents = evbuffer_reserve_space(evbuf, count,

--- a/src/net/buffer.hpp
+++ b/src/net/buffer.hpp
@@ -71,29 +71,15 @@ class IghtIovec : public ight::common::constraints::NonCopyable,
 	}
 };
 
-class IghtBuffer {
+class IghtBuffer : public ight::common::constraints::NonCopyable,
+		public ight::common::constraints::NonMovable  {
+
 	evbuffer *evbuf = NULL;
 
     public:
 	IghtBuffer(void) {
 		if ((evbuf = evbuffer_new()) == NULL)
 			throw std::bad_alloc();
-	}
-
-	IghtBuffer(IghtBuffer&) = delete;
-	IghtBuffer& operator=(IghtBuffer&) = delete;
-
-	/*
-	 * Note: move semantic entails an allocation. We can do better
-	 * by replacing the evbuffer with a wrapper object implementing
-	 * a lazy allocation strategy. (Coming soon...)
-	 */
-	IghtBuffer(IghtBuffer&& other) {
-		std::swap(evbuf, other.evbuf);
-	}
-	IghtBuffer& operator=(IghtBuffer&& other) {
-		std::swap(evbuf, other.evbuf);
-		return (*this);
 	}
 
 	~IghtBuffer(void) {

--- a/src/net/connection.h
+++ b/src/net/connection.h
@@ -9,6 +9,7 @@
 # define LIBIGHT_NET_CONNECTION_H
 # ifdef __cplusplus
 
+#include "common/constraints.hpp"
 #include "common/error.h"
 #include "common/poller.h"
 #include "common/utils.hpp"
@@ -128,7 +129,9 @@ class IghtConnectionState {
 	void close(void);
 };
 
-class IghtConnection {
+class IghtConnection : public ight::common::constraints::NonCopyable,
+		public ight::common::constraints::NonMovable {
+
 	IghtConnectionState *state = NULL;
 
     public:
@@ -141,18 +144,6 @@ class IghtConnection {
 	}
 	IghtConnection(const char *af, const char *a, const char *p) {
 		state = new IghtConnectionState(af, a, p);
-	}
-
-	/* We don't want multiple copies of `state` */
-	IghtConnection(IghtConnection&) = delete;
-	IghtConnection& operator=(IghtConnection&) = delete;
-
-	IghtConnection(IghtConnection&& other) {
-		std::swap(state, other.state);
-	}
-	IghtConnection& operator=(IghtConnection&& other) {
-		std::swap(state, other.state);
-		return (*this);
 	}
 
 	void close(void) {

--- a/src/ooni/tcp_test.cpp
+++ b/src/ooni/tcp_test.cpp
@@ -1,5 +1,6 @@
 #include "ooni/tcp_test.hpp"
 
+using namespace ight::common::pointer;
 using namespace ight::ooni::tcp_test;
 
 TCPClient
@@ -12,8 +13,8 @@ TCPTest::connect(ight::common::Settings options, std::function<void()>&& cb)
         options["host"] = "localhost";
     }
 
-    auto connection = IghtConnection("PF_UNSPEC", options["host"].c_str(),
-            options["port"].c_str());
+    auto connection = std::make_shared<IghtConnection>("PF_UNSPEC",
+            options["host"].c_str(), options["port"].c_str());
 
     //
     // FIXME The connection and this are bound in the
@@ -21,12 +22,12 @@ TCPTest::connect(ight::common::Settings options, std::function<void()>&& cb)
     // life cycles, which is &disaster.
     //
 
-    connection.on_error([cb, this](IghtError e) {
+    connection->on_error([cb, this](IghtError e) {
         entry["error_code"] = e.error;
         entry["connection"] = "failed";
         cb();
     });
-    connection.on_connect([this, cb]() {
+    connection->on_connect([this, cb]() {
         entry["connection"] = "success";
         cb();
     });

--- a/src/ooni/tcp_test.hpp
+++ b/src/ooni/tcp_test.hpp
@@ -3,14 +3,19 @@
 
 #include "net/buffer.hpp"
 #include "net/connection.h"
+
 #include "common/emitter.hpp"
+#include "common/pointer.hpp"
 #include "common/settings.hpp"
 #include "common/log.h"
+
 #include "ooni/net_test.hpp"
 
 namespace ight {
 namespace ooni {
 namespace tcp_test {
+
+using namespace ight::common::pointer;
 
 #if 0
 class TCPClient : public ight::common::emitter::EmitterVoid,
@@ -65,7 +70,7 @@ public:
 };
 #endif
 
-typedef IghtConnection TCPClient;           /* XXX */
+typedef SharedPointer<IghtConnection> TCPClient;           /* XXX */
 
 class TCPTest : public net_test::NetTest {
     using net_test::NetTest::NetTest;

--- a/src/protocols/http.hpp
+++ b/src/protocols/http.hpp
@@ -16,6 +16,7 @@
 #include <stdexcept>
 #include <string>
 
+#include "common/constraints.hpp"
 #include "common/settings.hpp"
 #include "common/log.h"
 #include "common/error.h"
@@ -35,6 +36,7 @@ namespace ight {
 namespace protocols {
 namespace http {
 
+using namespace ight::common::constraints;
 using namespace ight::common::pointer;
 
 /*!
@@ -531,7 +533,7 @@ typedef std::function<void(IghtError, Response&&)> RequestCallback;
 /*!
  * \brief HTTP request.
  */
-class Request {
+class Request : public NonCopyable, public NonMovable {
 
     RequestCallback callback;
     RequestSerializer serializer;
@@ -616,25 +618,6 @@ public:
             });
 
         });
-    }
-
-    Request(Request&) = delete;
-    Request& operator=(Request&) = delete;
-
-    Request(Request&& other) {
-        std::swap(callback, other.callback);
-        std::swap(serializer, other.serializer);
-        std::swap(stream, other.stream);
-        std::swap(response, other.response);
-        std::swap(parent, other.parent);
-    }
-    Request& operator=(Request&& other) {
-        std::swap(callback, other.callback);
-        std::swap(serializer, other.serializer);
-        std::swap(stream, other.stream);
-        std::swap(response, other.response);
-        std::swap(parent, other.parent);
-        return *this;
     }
 
     void close() {

--- a/src/protocols/http.hpp
+++ b/src/protocols/http.hpp
@@ -232,22 +232,22 @@ public:
  * degree of control is needed over the HTTP protocol.
  */
 class Stream {
-    IghtConnection connection;
+    SharedPointer<IghtConnection> connection;
     ResponseParser parser;
     std::function<void(IghtError)> error_handler;
 
     void connection_ready(void) {
-        if (connection.enable_read() != 0) {
+        if (connection->enable_read() != 0) {
             throw std::runtime_error("Cannot enable read");
         }
-        connection.on_data([&](evbuffer *data) {
+        connection->on_data([&](evbuffer *data) {
             parser.feed(data);
         });
         //
         // Intercept EOF error to implement body-ends-at-EOF semantic.
         // TODO: convert error from integer to exception.
         //
-        connection.on_error([&](IghtError error) {
+        connection->on_error([&](IghtError error) {
             if (error.error == 0) {
                 parser.eof();
             }
@@ -308,14 +308,14 @@ public:
      */
     Stream(std::string address, std::string port,
             std::string family = "PF_UNSPEC") {
-        connection = IghtConnection(family.c_str(), address.c_str(),
-                port.c_str());
+        connection = std::make_shared<IghtConnection>(family.c_str(),
+                address.c_str(), port.c_str());
         //
         // While the connection is in progress, just forward the
         // error if needed, we'll deal with body-terminated-by-EOF
         // semantic when we know we are actually connected.
         //
-        connection.on_error([&](IghtError error) {
+        connection->on_error([&](IghtError error) {
             if (error_handler) {
                 error_handler(error);
             }
@@ -327,7 +327,7 @@ public:
      * \sock The already connecte socket.
      */
     Stream(evutil_socket_t sock) {
-        connection = IghtConnection(sock);
+        connection = std::make_shared<IghtConnection>(sock);
         connection_ready();
     }
 
@@ -338,7 +338,7 @@ public:
      *         object attaching it to an already opened socket.
      */
     void on_connect(std::function<void(void)>&& fn) {
-        connection.on_connect([fn, this]() {
+        connection->on_connect([fn, this]() {
             connection_ready();
             fn();
         });
@@ -348,7 +348,7 @@ public:
      * \brief Close this stream.
      */
     void close() {
-        connection.close();
+        connection->close();
     }
 
     /*!
@@ -369,7 +369,7 @@ public:
      * \returns A reference to this stream for chaining operations.
      */
     Stream& operator<<(std::string data) {
-        if (connection.puts(data.c_str()) != 0) {
+        if (connection->puts(data.c_str()) != 0) {
             throw std::runtime_error("Cannot write into the connection");
         }
         return *this;
@@ -382,7 +382,7 @@ public:
      *         after some data was already passed to the kernel.
      */
     void on_flush(std::function<void(void)>&& fn) {
-        connection.on_flush(std::move(fn));
+        connection->on_flush(std::move(fn));
     }
 
     //
@@ -441,7 +441,7 @@ public:
      * \param time The timeout in seconds.
      */
     void set_timeout(double timeo) {
-        if (connection.set_timeout(timeo) != 0) {
+        if (connection->set_timeout(timeo) != 0) {
             throw std::runtime_error("Cannot set timeout");
         }
     }

--- a/test/echo_client_evbuf.cpp
+++ b/test/echo_client_evbuf.cpp
@@ -13,7 +13,7 @@
 int
 main(void)
 {
-	auto s = IghtConnection("PF_INET", "127.0.0.1", "54321");
+	IghtConnection s("PF_INET", "127.0.0.1", "54321");
 
 	s.on_connect([&](void) {
 		if (s.enable_read() != 0)

--- a/test/net/buffer.cpp
+++ b/test/net/buffer.cpp
@@ -22,8 +22,8 @@ TEST_CASE("The constructor works correctly", "[IghtBuffer]") {
 TEST_CASE("Insertion/extraction work correctly for evbuffer") {
 
 	IghtBuffer buff;
-	auto source = IghtEvbuffer();
-	auto dest = IghtEvbuffer();
+	IghtEvbuffer source;
+	IghtEvbuffer dest;
 	auto sa = std::string(65536, 'A');
 	auto r = std::string();
 

--- a/test/net/buffer.cpp
+++ b/test/net/buffer.cpp
@@ -16,12 +16,12 @@
 #include "net/buffer.hpp"
 
 TEST_CASE("The constructor works correctly", "[IghtBuffer]") {
-	REQUIRE_NOTHROW(auto buff = IghtBuffer());
+	REQUIRE_NOTHROW(IghtBuffer());
 }
 
 TEST_CASE("Insertion/extraction work correctly for evbuffer") {
 
-	auto buff = IghtBuffer();
+	IghtBuffer buff;
 	auto source = IghtEvbuffer();
 	auto dest = IghtEvbuffer();
 	auto sa = std::string(65536, 'A');
@@ -59,7 +59,7 @@ TEST_CASE("Insertion/extraction work correctly for evbuffer") {
 }
 
 TEST_CASE("length() works correctly", "[IghtBuffer]") {
-	auto buff = IghtBuffer();
+	IghtBuffer buff;
 
 	SECTION("Lengh is zero at the beginning") {
 		REQUIRE(buff.length() == 0);
@@ -79,7 +79,7 @@ TEST_CASE("length() works correctly", "[IghtBuffer]") {
 }
 
 TEST_CASE("Foreach is robust to corner cases and errors", "[IghtBuffer]") {
-	auto buff = IghtBuffer();
+	IghtBuffer buff;
 
 	SECTION("No function is invoked when the buffer is empty") {
 		buff.foreach([](evbuffer_iovec *) {
@@ -96,7 +96,7 @@ TEST_CASE("Foreach is robust to corner cases and errors", "[IghtBuffer]") {
 
 TEST_CASE("Foreach works correctly", "[IghtBuffer]") {
 
-	auto buff = IghtBuffer();
+	IghtBuffer buff;
 	auto counter = 0;
 	auto r = std::string();
 
@@ -155,7 +155,7 @@ TEST_CASE("Foreach works correctly", "[IghtBuffer]") {
 }
 
 TEST_CASE("Discard works correctly", "[IghtBuffer]") {
-	auto buff = IghtBuffer();
+	IghtBuffer buff;
 
 	SECTION("Discard does not misbehave when the buffer is empty") {
 		buff.discard(1024);
@@ -188,7 +188,7 @@ TEST_CASE("Discard works correctly", "[IghtBuffer]") {
 }
 
 TEST_CASE("Read works correctly") {
-	auto buff = IghtBuffer();
+	IghtBuffer buff;
 
 	SECTION("Read does not misbehave when the buffer is empty") {
 		auto s = buff.read<char>(65535);
@@ -230,7 +230,7 @@ TEST_CASE("Read works correctly") {
 }
 
 TEST_CASE("Readn works correctly") {
-	auto buff = IghtBuffer();
+	IghtBuffer buff;
 
 	SECTION("Readn does not misbehave when the buffer is empty") {
 		auto s = buff.readn<char>(65535);
@@ -265,7 +265,7 @@ TEST_CASE("Readn works correctly") {
 }
 
 TEST_CASE("Readline works correctly", "[IghtBuffer]") {
-	auto buff = IghtBuffer();
+	IghtBuffer buff;
 	auto s = std::string();
 	int error = 0;
 
@@ -334,7 +334,7 @@ TEST_CASE("Readline works correctly", "[IghtBuffer]") {
 }
 
 TEST_CASE("Write works correctly", "[IghtBuffer]") {
-	auto buff = IghtBuffer();
+	IghtBuffer buff;
 	auto pc = "0123456789";
 	auto str = std::string(pc);
 	auto vect = std::vector<char>(str.begin(), str.end());

--- a/test/net/connection.cpp
+++ b/test/net/connection.cpp
@@ -19,17 +19,17 @@ TEST_CASE("Ensure that the constructor socket-validity checks work") {
 	SECTION("Invalid values are properly normalized") {
 		{
 			/* Common for both Unix and Windows */
-			auto conn = IghtConnection(-1);
+			IghtConnection conn(-1);
 			REQUIRE(conn.get_fileno() == -1);
 		}
 #ifndef WIN32
 		{
-			auto conn = IghtConnection(-2);
+			IghtConnection conn(-2);
 			REQUIRE(conn.get_fileno() == -1);
 		}
 		/* ... */
 		{
-			auto conn = IghtConnection(INT_MIN);
+			IghtConnection conn(INT_MIN);
 			REQUIRE(conn.get_fileno() == -1);
 		}
 #endif
@@ -37,39 +37,39 @@ TEST_CASE("Ensure that the constructor socket-validity checks work") {
 
 	SECTION("Valid values are accepted") {
 		{
-			auto conn = IghtConnection(0);
+			IghtConnection conn(0);
 			REQUIRE(conn.get_fileno() == 0);
 		}
 		{
-			auto conn = IghtConnection(1);
+			IghtConnection conn(1);
 			REQUIRE(conn.get_fileno() == 1);
 		}
 		{
-			auto conn = IghtConnection(2);
+			IghtConnection conn(2);
 			REQUIRE(conn.get_fileno() == 2);
 		}
 #ifdef WIN32
 		{
-			auto conn = IghtConnection(INTPTR_MAX);
+			IghtConnection conn(INTPTR_MAX);
 			REQUIRE(conn.get_fileno() == INTPTR_MAX);
 		}
 		/* Skip -1 that is INVALID_SOCKET */
 		{
-			auto conn = IghtConnection(-2);
+			IghtConnection conn(-2);
 			REQUIRE(conn.get_fileno() == -2);
 		}
 		{
-			auto conn = IghtConnection(-3);
+			IghtConnection conn(-3);
 			REQUIRE(conn.get_fileno() == -3);
 		}
 		/* ... */
 		{
-			auto conn = IghtConnection(INTPTR_MIN);
+			IghtConnection conn(INTPTR_MIN);
 			REQUIRE(conn.get_fileno() == INTPTR_MIN);
 		}
 #else
 		{
-			auto conn = IghtConnection(INT_MAX);
+			IghtConnection conn(INT_MAX);
 			REQUIRE(conn.get_fileno() == INT_MAX);
 		}
 

--- a/test/protocols/http.cpp
+++ b/test/protocols/http.cpp
@@ -179,7 +179,7 @@ TEST_CASE("HTTP Request serializer works as expected") {
     }, {
         {"User-Agent", "Antani/1.0.0.0"},
     }, "0123456789");
-    auto buffer = IghtBuffer();
+    IghtBuffer buffer;
     serializer.serialize(buffer);
     auto serialized = buffer.read<char>();
     std::string expect = "GET /antani?clacsonato=yes HTTP/1.0\r\n";
@@ -193,7 +193,7 @@ TEST_CASE("HTTP Request serializer works as expected") {
 
 TEST_CASE("HTTP Request works as expected") {
     //ight_set_verbose(1);
-    auto r = http::Request({
+    http::Request r({
         {"url", "http://www.google.com/robots.txt"},
         {"method", "GET"},
         {"http_version", "HTTP/1.1"},
@@ -221,7 +221,7 @@ TEST_CASE("HTTP Request works as expected") {
 
 TEST_CASE("HTTP Request correctly receives errors") {
     ight_set_verbose(1);
-    auto r = http::Request({
+    http::Request r({
         {"url", "http://nexa.polito.it:81/robots.txt"},
         {"method", "GET"},
         {"http_version", "HTTP/1.1"},


### PR DESCRIPTION
This fixes the move semantic in `src/net`. If an object does not contain pointers to C structures allocated on the help and does not contain lambdas bound to this and does not contain callbacks, make it copyable and movable. Otherwise, make it non copyable and non movable and, when we need to copy and/or move it, allocate it on the heap and manage its lifecycle using a SharedPointer.