### PR TITLE
Connection: no separately managed socket

### DIFF
--- a/src/common/libevent.h
+++ b/src/common/libevent.h
@@ -177,7 +177,15 @@ class IghtBuffereventSocket : public ight::common::constraints::NonCopyable,
 
 	IghtBuffereventSocket(event_base *base, evutil_socket_t fd,
 	    int options, IghtLibevent *lev = NULL) {
-		if (lev != NULL)
+		make(base, fd, options, lev);
+	}
+
+	void make(event_base *base, evutil_socket_t fd,
+	    int options, IghtLibevent *lev = NULL) {
+		close();
+		if (lev == NULL)
+			libevent = IghtGlobalLibevent::get();
+		else
 			libevent = lev;
 		if ((bev = libevent->bufferevent_socket_new(base, fd,
 		    options)) == NULL)
@@ -185,8 +193,14 @@ class IghtBuffereventSocket : public ight::common::constraints::NonCopyable,
 	}
 
 	~IghtBuffereventSocket(void) {
-		if (bev != NULL)
+		close();
+	}
+
+	void close() {
+		if (bev != NULL) {
 			libevent->bufferevent_free(bev);
+			bev = NULL;
+		}
 	}
 
 	operator bufferevent *(void) {

--- a/src/net/connection.cpp
+++ b/src/net/connection.cpp
@@ -264,6 +264,7 @@ IghtConnectionState::handle_resolve(int result, char type, int count,
 		abort();
 
 	if (self->closing) {
+		ight_info("handle_resolve - delayed close");
 		delete (self);
 		return;
 	}

--- a/src/net/connection.cpp
+++ b/src/net/connection.cpp
@@ -237,25 +237,20 @@ IghtConnectionState::connect_next(void)
 }
 
 void
-IghtConnectionState::handle_resolve(int result, char type, int count,
-    int ttl, void *addresses, void *opaque)
-{
-	auto self = (IghtConnectionState *) opaque;
-	const char *_family;
-	const char *p;
-	int error, family, size;
-	char string[128];
+IghtConnectionState::handle_resolve(int result, char type,
+		std::vector<std::string> results) {
 
-	(void) ttl;
+	const char *_family;
+	int error;
 
 	ight_info("handle_resolve - enter");
 
-	if (!self->connecting)
+	if (!connecting)
 		abort();
 
-	if (self->closing) {
+	if (closing) {
 		ight_info("handle_resolve - delayed close");
-		delete (self);
+		delete this;
 		return;
 	}
 
@@ -265,70 +260,75 @@ IghtConnectionState::handle_resolve(int result, char type, int count,
 	switch (type) {
 	case DNS_IPv4_A:
 		ight_info("handle_resolve - IPv4");
-		family = PF_INET;
 		_family = "PF_INET";
-		size = 4;
 		break;
 	case DNS_IPv6_AAAA:
 		ight_info("handle_resolve - IPv6");
-		family = PF_INET6;
 		_family = "PF_INET6";
-		size = 16;
 		break;
 	default:
 		abort();
 	}
 
-	while (--count >= 0) {
-		if (count > INT_MAX / size) {
-			continue;
-		}
-		// Note: address already in network byte order
-		p = inet_ntop(family, (char *)addresses + count * size,
-		    string, sizeof (string));
-		if (p == NULL) {
-			ight_warn("handle_resolve - inet_ntop() failed");
-			continue;
-		}
-		ight_info("handle_resolve - address %s", p);
-		error = self->addrlist->append(string);
+	for (auto& address : results) {
+		ight_info("handle_resolve - address %s", address.c_str());
+		error = addrlist->append(address.c_str());
 		if (error != 0) {
 			ight_warn("handle_resolve - cannot append");
 			continue;
 		}
 		ight_info("handle_resolve - family %s", _family);
-		error = self->pflist->append(_family);
+		error = pflist->append(_family);
 		if (error != 0) {
 			ight_warn("handle_resolve - cannot append");
 			// Oops the two vectors are not in sync anymore now
-			self->connecting = 0;
-			self->on_error(IghtError(-3));
+			connecting = 0;
+			on_error(IghtError(-3));
 			return;
 		}
 	}
 
     finally:
-	auto dns_base = ight_get_global_evdns_base();
+	if (must_resolve_ipv6) {
+		must_resolve_ipv6 = 0;
+		bool ok = resolve_internal(DNS_IPv6_AAAA);
+		if (ok)
+			return;
+		/* FALLTHROUGH */
+	}
+	if (must_resolve_ipv4) {
+		must_resolve_ipv4 = 0;
+		bool ok = resolve_internal(DNS_IPv4_A);
+		if (ok)
+			return;
+		/* FALLTHROUGH */
+	}
+	connect_next();
+}
 
-	if (self->must_resolve_ipv6) {
-		self->must_resolve_ipv6 = 0;
-		evdns_request *request = evdns_base_resolve_ipv6(dns_base,
-		    self->address, DNS_QUERY_NO_SEARCH, self->handle_resolve,
-		    self);
-		if (request != NULL)
-			return;
-		/* FALLTHROUGH */
-	}
-	if (self->must_resolve_ipv4) {
-		self->must_resolve_ipv4 = 0;
-		evdns_request *request = evdns_base_resolve_ipv4(dns_base,
-		    self->address, DNS_QUERY_NO_SEARCH, self->handle_resolve,
-		    self);
-		if (request != NULL)
-			return;
-		/* FALLTHROUGH */
-	}
-	self->connect_next();
+bool IghtConnectionState::resolve_internal(char type) {
+
+    std::string query;
+
+    if (type == DNS_IPv6_AAAA) {
+        query = "AAAA";
+    } else if (type == DNS_IPv4_A) {
+        query = "A";
+    } else {
+        return false;
+    }
+
+    try {
+        dns_request = ight::protocols::dns::Request(query, address,
+                [this, type](ight::protocols::dns::Response&& resp) {
+            handle_resolve(resp.get_evdns_status(), type,
+                    resp.get_results());
+        });
+    } catch (...) {
+        return false;  /* TODO: save the error */
+    }
+
+    return true;
 }
 
 void
@@ -379,8 +379,6 @@ IghtConnectionState::resolve(IghtConnectionState *self)
 		return;
 	}
 
-	auto dns_base = ight_get_global_evdns_base();
-
 	// Note: PF_UNSPEC6 means that we try with IPv6 first
 	if (strcmp(self->family, "PF_INET") == 0)
 		self->must_resolve_ipv4 = 1;
@@ -397,18 +395,16 @@ IghtConnectionState::resolve(IghtConnectionState *self)
 		return;
 	}
 
-	evdns_request *request;
+	bool ok = false;
 
 	if (self->must_resolve_ipv4) {
 		self->must_resolve_ipv4 = 0;
-		request = evdns_base_resolve_ipv4(dns_base, self->address,
-		    DNS_QUERY_NO_SEARCH, self->handle_resolve, self);
+		ok = self->resolve_internal(DNS_IPv4_A);
 	} else {
 		self->must_resolve_ipv6 = 0;
-		request = evdns_base_resolve_ipv6(dns_base, self->address,
-		    DNS_QUERY_NO_SEARCH, self->handle_resolve, self);
+		ok = self->resolve_internal(DNS_IPv6_AAAA);
 	}
-	if (request == NULL) {
+	if (!ok) {
 		self->connecting = 0;
 		self->on_error(IghtError(-6));
 		return;
@@ -426,6 +422,7 @@ IghtConnectionState::close(void)
 {
 	this->closing = 1;
 	this->bev.close();
+	this->dns_request.cancel();
 	if (this->reading != 0 || this->connecting != 0)
 		return;
 	delete this;

--- a/src/net/connection.h
+++ b/src/net/connection.h
@@ -29,11 +29,9 @@ struct evbuffer;
 class IghtConnectionState {
 
 	evutil_socket_t filedesc = IGHT_SOCKET_INVALID;
-	unsigned int closing = 0;
 	IghtBuffereventSocket bev;
 	ight::protocols::dns::Request dns_request;
 	unsigned int connecting = 0;
-	unsigned int reading = 0;
 	char *address = NULL;
 	char *port = NULL;
 	IghtStringVector *addrlist = NULL;
@@ -42,9 +40,6 @@ class IghtConnectionState {
 	unsigned int must_resolve_ipv4 = 0;
 	unsigned int must_resolve_ipv6 = 0;
 	ight::common::pointer::SharedPointer<IghtDelayedCall> start_connect;
-
-	// Private destructor because destruction may be delayed
-	~IghtConnectionState(void);
 
 	// Libevent callbacks
 	static void handle_read(bufferevent *, void *);
@@ -65,6 +60,8 @@ class IghtConnectionState {
 	IghtConnectionState& operator=(IghtConnectionState&) = delete;
 	IghtConnectionState(IghtConnectionState&&) = delete;
 	IghtConnectionState& operator=(IghtConnectionState&&) = delete;
+
+	~IghtConnectionState(void);
 
 	std::function<void(void)> on_connect = [](void) {
 		/* nothing */
@@ -151,10 +148,7 @@ class IghtConnection : public ight::common::constraints::NonCopyable,
 	}
 
 	void close(void) {
-		if (state == NULL)
-			return;
 		state->close();
-		state = NULL;		/* Idempotent */
 	}
 
 	~IghtConnection(void) {

--- a/src/net/connection.h
+++ b/src/net/connection.h
@@ -27,8 +27,8 @@ struct evbuffer;
 class IghtConnectionState {
 
 	evutil_socket_t filedesc = IGHT_SOCKET_INVALID;
-	bufferevent *bev = NULL;
 	unsigned int closing = 0;
+	IghtBuffereventSocket bev;
 	unsigned int connecting = 0;
 	unsigned int reading = 0;
 	char *address = NULL;

--- a/src/net/connection.h
+++ b/src/net/connection.h
@@ -15,6 +15,8 @@
 #include "common/poller.h"
 #include "common/utils.hpp"
 
+#include "protocols/dns.hpp"
+
 #include <event2/bufferevent.h>
 #include <event2/event.h>
 
@@ -29,6 +31,7 @@ class IghtConnectionState {
 	evutil_socket_t filedesc = IGHT_SOCKET_INVALID;
 	unsigned int closing = 0;
 	IghtBuffereventSocket bev;
+	ight::protocols::dns::Request dns_request;
 	unsigned int connecting = 0;
 	unsigned int reading = 0;
 	char *address = NULL;
@@ -50,9 +53,9 @@ class IghtConnectionState {
 
 	// Functions used when connecting
 	void connect_next(void);
-	static void handle_resolve(int, char, int, int,
-	    void *, void *);
+	void handle_resolve(int, char, std::vector<std::string>);
 	static void resolve(IghtConnectionState *);
+	bool resolve_internal(char);
 
     public:
 	IghtConnectionState(const char *, const char *, const char *,

--- a/src/net/connection.h
+++ b/src/net/connection.h
@@ -28,7 +28,6 @@ struct evbuffer;
 
 class IghtConnectionState {
 
-	evutil_socket_t filedesc = IGHT_SOCKET_INVALID;
 	IghtBuffereventSocket bev;
 	ight::protocols::dns::Request dns_request;
 	unsigned int connecting = 0;
@@ -84,7 +83,7 @@ class IghtConnectionState {
 	};
 
 	evutil_socket_t get_fileno(void) {
-		return (this->filedesc);
+		return (bufferevent_getfd(this->bev));
 	}
 
 	int set_timeout(double timeout) {

--- a/src/net/connection.h
+++ b/src/net/connection.h
@@ -149,14 +149,12 @@ class IghtConnection : public ight::common::constraints::NonCopyable,
 
 	void close(void) {
 		if (state == NULL)
-			return;
+			throw std::runtime_error("Invalid state");
 		state->close();
-		delete state;
-		state = NULL;		/* Idempotent */
 	}
 
 	~IghtConnection(void) {
-		close();
+		delete state;  /* delete handles NULL */
 	}
 
 	void on_connect(std::function<void(void)>&& fn) {

--- a/src/net/connection.h
+++ b/src/net/connection.h
@@ -148,7 +148,11 @@ class IghtConnection : public ight::common::constraints::NonCopyable,
 	}
 
 	void close(void) {
+		if (state == NULL)
+			return;
 		state->close();
+		delete state;
+		state = NULL;		/* Idempotent */
 	}
 
 	~IghtConnection(void) {

--- a/test/net/connection.cpp
+++ b/test/net/connection.cpp
@@ -12,6 +12,9 @@
 #define CATCH_CONFIG_MAIN
 #include "src/ext/Catch/single_include/catch.hpp"
 
+#include "common/check_connectivity.hpp"
+#include "common/log.h"
+
 #include "net/connection.h"
 
 TEST_CASE("Ensure that the constructor socket-validity checks work") {
@@ -75,4 +78,58 @@ TEST_CASE("Ensure that the constructor socket-validity checks work") {
 
 #endif
 	}
+}
+
+TEST_CASE("IghtConnection::close() is idempotent") {
+    if (ight::Network::is_down()) {
+        return;
+    }
+    IghtConnection s("PF_INET", "nexa.polito.it", "80");
+    s.on_connect([&s]() {
+        REQUIRE(s.enable_read() == 0);
+        REQUIRE(s.puts("GET / HTTP/1.0\r\n\r\n") == 0);
+    });
+    s.on_data([&s](evbuffer *) {
+        s.close();
+        // It shall be safe to call close() more than once
+        s.close();
+        s.close();
+        ight_break_loop();
+    });
+    ight_loop();
+}
+
+TEST_CASE("It is safe to manipulate IghtConnection after close") {
+    if (ight::Network::is_down()) {
+        return;
+    }
+    IghtConnection s("PF_INET", "nexa.polito.it", "80");
+    s.on_connect([&s]() {
+        REQUIRE(s.enable_read() == 0);
+        REQUIRE(s.puts("GET / HTTP/1.0\r\n\r\n") == 0);
+    });
+    s.on_data([&s](evbuffer *) {
+        s.close();
+        // It shall be safe to call any API after close()
+	// where safe means that we don't segfault
+        REQUIRE_THROWS(s.enable_read());
+        REQUIRE_THROWS(s.disable_read());
+        ight_break_loop();
+    });
+    ight_loop();
+}
+
+TEST_CASE("It is safe to close IghtConnection while resolve is in progress") {
+    if (ight::Network::is_down()) {
+        return;
+    }
+    ight_set_verbose(1);
+    IghtConnection s("PF_INET", "nexa.polito.it", "80");
+    IghtDelayedCall unsched(0.001, [&s]() {
+        s.close();
+    });
+    IghtDelayedCall bail_out(2.0, []() {
+        ight_break_loop();
+    });
+    ight_loop();
 }


### PR DESCRIPTION
Do not manage the socket separately. I've checked that libevent is robust with respect to calling close(-1) when the filedescriptor is not set for a long time now.