### PR TITLE
Implement socks5

### DIFF
--- a/src/common/libevent.h
+++ b/src/common/libevent.h
@@ -177,7 +177,15 @@ class IghtBuffereventSocket : public ight::common::constraints::NonCopyable,
 
 	IghtBuffereventSocket(event_base *base, evutil_socket_t fd,
 	    int options, IghtLibevent *lev = NULL) {
-		if (lev != NULL)
+		make(base, fd, options, lev);
+	}
+
+	void make(event_base *base, evutil_socket_t fd,
+	    int options, IghtLibevent *lev = NULL) {
+		close();
+		if (lev == NULL)
+			libevent = IghtGlobalLibevent::get();
+		else
 			libevent = lev;
 		if ((bev = libevent->bufferevent_socket_new(base, fd,
 		    options)) == NULL)
@@ -185,8 +193,14 @@ class IghtBuffereventSocket : public ight::common::constraints::NonCopyable,
 	}
 
 	~IghtBuffereventSocket(void) {
-		if (bev != NULL)
+		close();
+	}
+
+	void close() {
+		if (bev != NULL) {
 			libevent->bufferevent_free(bev);
+			bev = NULL;
+		}
 	}
 
 	operator bufferevent *(void) {

--- a/src/net/buffer.cpp
+++ b/src/net/buffer.cpp
@@ -1,0 +1,24 @@
+/*-
+ * This file is part of Libight <https://libight.github.io/>.
+ *
+ * Libight is free software. See AUTHORS and LICENSE for more
+ * information on the copying conditions.
+ */
+
+#include <arpa/inet.h>
+
+#include "net/buffer.hpp"
+
+void IghtBuffer::write_uint8(uint8_t num) {
+    write(&num, sizeof (num));
+}
+
+void IghtBuffer::write_uint16(uint16_t num) {
+    num = htons(num);
+    write(&num, sizeof (num));
+}
+
+void IghtBuffer::write_uint32(uint32_t num) {
+    num = htonl(num);
+    write(&num, sizeof (num));
+}

--- a/src/net/buffer.hpp
+++ b/src/net/buffer.hpp
@@ -168,7 +168,8 @@ class IghtBuffer : public ight::common::constraints::NonCopyable,
 	 * appropriate, because it is surprising to store binary data into
 	 * an std::string, which is designed to hold text).
 	 */
-	template<typename T> std::basic_string<T> read(size_t upto) {
+	template<typename T> std::basic_string<T> readpeek(bool ispeek,
+			size_t upto) {
 		size_t nbytes = 0;
 		std::basic_string<T> out;
 
@@ -191,13 +192,34 @@ class IghtBuffer : public ight::common::constraints::NonCopyable,
 		 * We do this after foreach() because we are not supposed
 		 * to modify the underlying `evbuf` during foreach().
 		 */
-		discard(nbytes);
+		if (!ispeek)
+			discard(nbytes);
 
 		return (out);
 	}
 
+	template<typename T> std::basic_string<T> read(size_t upto) {
+		return readpeek<T>(false, upto);
+        }
+
 	template<typename T> std::basic_string<T> read(void) {
 		return (read<T>(length()));
+	}
+
+	std::string read(size_t upto) {
+		return read<char>(upto);
+	}
+
+	std::string read() {
+		return read<char>();
+	}
+
+	std::string peek(size_t upto) {
+		return readpeek<char>(true, upto);
+	}
+
+	std::string peek() {
+		return peek(length());
 	}
 
 	/*
@@ -208,6 +230,10 @@ class IghtBuffer : public ight::common::constraints::NonCopyable,
 		if (n > length())
 			return (std::basic_string<T>());	/* Empty str */
 		return (read<T>(n));
+	}
+
+	std::string readn(size_t n) {
+		return readn<char>(n);
 	}
 
 	std::tuple<int, std::string> readline(size_t maxline) {
@@ -274,6 +300,12 @@ class IghtBuffer : public ight::common::constraints::NonCopyable,
 		if (evbuffer_add(evbuf, buf, count) != 0)
 			throw std::runtime_error("evbuffer_add failed");
 	}
+
+	void write_uint8(uint8_t);
+
+	void write_uint16(uint16_t);
+
+	void write_uint32(uint32_t);
 
 	void write_rand(size_t count) {
 		if (count == 0)

--- a/src/net/buffer.hpp
+++ b/src/net/buffer.hpp
@@ -74,12 +74,16 @@ class IghtIovec : public ight::common::constraints::NonCopyable,
 class IghtBuffer : public ight::common::constraints::NonCopyable,
 		public ight::common::constraints::NonMovable  {
 
-	evbuffer *evbuf = NULL;
+	evbuffer *evbuf;
 
     public:
-	IghtBuffer(void) {
+	IghtBuffer(evbuffer *b = NULL) {
 		if ((evbuf = evbuffer_new()) == NULL)
 			throw std::bad_alloc();
+		if (b != NULL && evbuffer_add_buffer(evbuf, b) != 0) {
+			evbuffer_free(evbuf);
+			throw std::runtime_error("evbuffer_add_buffer failed");
+		}
 	}
 
 	~IghtBuffer(void) {
@@ -105,6 +109,16 @@ class IghtBuffer : public ight::common::constraints::NonCopyable,
 			throw std::runtime_error("dest is NULL");
 		if (evbuffer_add_buffer(dest, evbuf) != 0)
 			throw std::runtime_error("evbuffer_add_buffer failed");
+		return (*this);
+	}
+
+	IghtBuffer& operator<<(IghtBuffer& source) {
+		*this << source.evbuf;
+		return (*this);
+	}
+
+	IghtBuffer& operator>>(IghtBuffer& source) {
+		*this >> source.evbuf;
 		return (*this);
 	}
 

--- a/src/net/connection.cpp
+++ b/src/net/connection.cpp
@@ -264,6 +264,7 @@ IghtConnectionState::handle_resolve(int result, char type, int count,
 		abort();
 
 	if (self->closing) {
+		ight_info("handle_resolve - delayed close");
 		delete (self);
 		return;
 	}

--- a/src/net/connection.cpp
+++ b/src/net/connection.cpp
@@ -14,7 +14,7 @@
 
 #include "common/log.h"
 #include "common/stringvector.h"
-#include "net/connection.h"
+#include "net/connection.hpp"
 
 using namespace ight::net::connection;
 using namespace ight::protocols;

--- a/src/net/connection.cpp
+++ b/src/net/connection.cpp
@@ -16,7 +16,10 @@
 #include "common/stringvector.h"
 #include "net/connection.h"
 
-IghtConnectionState::~IghtConnectionState(void)
+using namespace ight::net::connection;
+using namespace ight::protocols;
+
+ConnectionState::~ConnectionState(void)
 {
 	/*
 	 * TODO: switch to RAII.
@@ -41,25 +44,25 @@ IghtConnectionState::~IghtConnectionState(void)
 }
 
 void
-IghtConnectionState::handle_read(bufferevent *bev, void *opaque)
+ConnectionState::handle_read(bufferevent *bev, void *opaque)
 {
-	auto self = (IghtConnectionState *) opaque;
+	auto self = (ConnectionState *) opaque;
 	(void) bev;  // Suppress warning about unused variable
 	self->on_data_fn(bufferevent_get_input(self->bev));
 }
 
 void
-IghtConnectionState::handle_write(bufferevent *bev, void *opaque)
+ConnectionState::handle_write(bufferevent *bev, void *opaque)
 {
-	auto self = (IghtConnectionState *) opaque;
+	auto self = (ConnectionState *) opaque;
 	(void) bev;  // Suppress warning about unused variable
 	self->on_flush_fn();
 }
 
 void
-IghtConnectionState::handle_event(bufferevent *bev, short what, void *opaque)
+ConnectionState::handle_event(bufferevent *bev, short what, void *opaque)
 {
-	auto self = (IghtConnectionState *) opaque;
+	auto self = (ConnectionState *) opaque;
 
 	(void) bev;  // Suppress warning about unused variable
 
@@ -85,7 +88,7 @@ IghtConnectionState::handle_event(bufferevent *bev, short what, void *opaque)
 	self->on_error_fn(IghtError(-1));
 }
 
-IghtConnectionState::IghtConnectionState(const char *family, const char *address,
+ConnectionState::ConnectionState(const char *family, const char *address,
     const char *port, evutil_socket_t filenum)
 {
 	auto evbase = ight_get_global_event_base();
@@ -152,7 +155,7 @@ IghtConnectionState::IghtConnectionState(const char *family, const char *address
 }
 
 void
-IghtConnectionState::connect_next(void)
+ConnectionState::connect_next(void)
 {
 	const char *address;
 	int error;
@@ -212,7 +215,7 @@ IghtConnectionState::connect_next(void)
 }
 
 void
-IghtConnectionState::handle_resolve(int result, char type,
+ConnectionState::handle_resolve(int result, char type,
 		std::vector<std::string> results) {
 
 	const char *_family;
@@ -275,7 +278,7 @@ IghtConnectionState::handle_resolve(int result, char type,
 	connect_next();
 }
 
-bool IghtConnectionState::resolve_internal(char type) {
+bool ConnectionState::resolve_internal(char type) {
 
     std::string query;
 
@@ -288,8 +291,8 @@ bool IghtConnectionState::resolve_internal(char type) {
     }
 
     try {
-        dns_request = ight::protocols::dns::Request(query, address,
-                [this, type](ight::protocols::dns::Response&& resp) {
+        dns_request = dns::Request(query, address, [this, type](
+                dns::Response&& resp) {
             handle_resolve(resp.get_evdns_status(), type,
                     resp.get_results());
         });
@@ -301,7 +304,7 @@ bool IghtConnectionState::resolve_internal(char type) {
 }
 
 void
-IghtConnectionState::resolve(IghtConnectionState *self)
+ConnectionState::resolve(ConnectionState *self)
 {
 	struct sockaddr_storage storage;
 	int result;
@@ -382,7 +385,7 @@ IghtConnectionState::resolve(IghtConnectionState *self)
 }
 
 void
-IghtConnectionState::close(void)
+ConnectionState::close(void)
 {
 	this->bev.close();
 	this->dns_request.cancel();

--- a/src/net/connection.cpp
+++ b/src/net/connection.cpp
@@ -48,7 +48,8 @@ ConnectionState::handle_read(bufferevent *bev, void *opaque)
 {
 	auto self = (ConnectionState *) opaque;
 	(void) bev;  // Suppress warning about unused variable
-	self->on_data_fn(bufferevent_get_input(self->bev));
+	self->on_data_fn(std::make_shared<IghtBuffer>(
+			bufferevent_get_input(self->bev)));
 }
 
 void

--- a/src/net/connection.cpp
+++ b/src/net/connection.cpp
@@ -45,7 +45,7 @@ IghtConnectionState::handle_read(bufferevent *bev, void *opaque)
 {
 	auto self = (IghtConnectionState *) opaque;
 	(void) bev;  // Suppress warning about unused variable
-	self->on_data(bufferevent_get_input(self->bev));
+	self->on_data_fn(bufferevent_get_input(self->bev));
 }
 
 void
@@ -53,7 +53,7 @@ IghtConnectionState::handle_write(bufferevent *bev, void *opaque)
 {
 	auto self = (IghtConnectionState *) opaque;
 	(void) bev;  // Suppress warning about unused variable
-	self->on_flush();
+	self->on_flush_fn();
 }
 
 void
@@ -65,12 +65,12 @@ IghtConnectionState::handle_event(bufferevent *bev, short what, void *opaque)
 
 	if (what & BEV_EVENT_CONNECTED) {
 		self->connecting = 0;
-		self->on_connect();
+		self->on_connect_fn();
 		return;
 	}
 
 	if (what & BEV_EVENT_EOF) {
-		self->on_error(IghtError(0));
+		self->on_error_fn(IghtError(0));
 		return;
 	}
 
@@ -82,7 +82,7 @@ IghtConnectionState::handle_event(bufferevent *bev, short what, void *opaque)
 
 	// TODO: also handle the timeout
 
-	self->on_error(IghtError(-1));
+	self->on_error_fn(IghtError(-1));
 }
 
 IghtConnectionState::IghtConnectionState(const char *family, const char *address,
@@ -208,7 +208,7 @@ IghtConnectionState::connect_next(void)
 	}
 
 	this->connecting = 0;
-	this->on_error(IghtError(-2));
+	this->on_error_fn(IghtError(-2));
 }
 
 void
@@ -252,7 +252,7 @@ IghtConnectionState::handle_resolve(int result, char type,
 			ight_warn("handle_resolve - cannot append");
 			// Oops the two vectors are not in sync anymore now
 			connecting = 0;
-			on_error(IghtError(-3));
+			on_error_fn(IghtError(-3));
 			return;
 		}
 	}
@@ -319,7 +319,7 @@ IghtConnectionState::resolve(IghtConnectionState *self)
 		    self->pflist->append("PF_INET") != 0) {
 			ight_warn("resolve - cannot append");
 			self->connecting = 0;
-			self->on_error(IghtError(-4));
+			self->on_error_fn(IghtError(-4));
 			return;
 		}
 		self->connect_next();
@@ -336,7 +336,7 @@ IghtConnectionState::resolve(IghtConnectionState *self)
 		    self->pflist->append("PF_INET6") != 0) {
 			ight_warn("resolve - cannot append");
 			self->connecting = 0;
-			self->on_error(IghtError(-4));
+			self->on_error_fn(IghtError(-4));
 			return;
 		}
 		self->connect_next();
@@ -355,7 +355,7 @@ IghtConnectionState::resolve(IghtConnectionState *self)
 	else {
 		ight_warn("connection::resolve - invalid PF_xxx");
 		self->connecting = 0;
-		self->on_error(IghtError(-5));
+		self->on_error_fn(IghtError(-5));
 		return;
 	}
 
@@ -370,7 +370,7 @@ IghtConnectionState::resolve(IghtConnectionState *self)
 	}
 	if (!ok) {
 		self->connecting = 0;
-		self->on_error(IghtError(-6));
+		self->on_error_fn(IghtError(-6));
 		return;
 	}
 

--- a/src/net/connection.cpp
+++ b/src/net/connection.cpp
@@ -391,3 +391,7 @@ ConnectionState::close(void)
 	this->bev.close();
 	this->dns_request.cancel();
 }
+
+Connection::~Connection() {
+    delete state;  /* delete handles NULL */
+}

--- a/src/net/connection.cpp
+++ b/src/net/connection.cpp
@@ -237,25 +237,20 @@ IghtConnectionState::connect_next(void)
 }
 
 void
-IghtConnectionState::handle_resolve(int result, char type, int count,
-    int ttl, void *addresses, void *opaque)
-{
-	auto self = (IghtConnectionState *) opaque;
-	const char *_family;
-	const char *p;
-	int error, family, size;
-	char string[128];
+IghtConnectionState::handle_resolve(int result, char type,
+		std::vector<std::string> results) {
 
-	(void) ttl;
+	const char *_family;
+	int error;
 
 	ight_info("handle_resolve - enter");
 
-	if (!self->connecting)
+	if (!connecting)
 		abort();
 
-	if (self->closing) {
+	if (closing) {
 		ight_info("handle_resolve - delayed close");
-		delete (self);
+		delete this;
 		return;
 	}
 
@@ -265,70 +260,75 @@ IghtConnectionState::handle_resolve(int result, char type, int count,
 	switch (type) {
 	case DNS_IPv4_A:
 		ight_info("handle_resolve - IPv4");
-		family = PF_INET;
 		_family = "PF_INET";
-		size = 4;
 		break;
 	case DNS_IPv6_AAAA:
 		ight_info("handle_resolve - IPv6");
-		family = PF_INET6;
 		_family = "PF_INET6";
-		size = 16;
 		break;
 	default:
 		abort();
 	}
 
-	while (--count >= 0) {
-		if (count > INT_MAX / size) {
-			continue;
-		}
-		// Note: address already in network byte order
-		p = inet_ntop(family, (char *)addresses + count * size,
-		    string, sizeof (string));
-		if (p == NULL) {
-			ight_warn("handle_resolve - inet_ntop() failed");
-			continue;
-		}
-		ight_info("handle_resolve - address %s", p);
-		error = self->addrlist->append(string);
+	for (auto& address : results) {
+		ight_info("handle_resolve - address %s", address.c_str());
+		error = addrlist->append(address.c_str());
 		if (error != 0) {
 			ight_warn("handle_resolve - cannot append");
 			continue;
 		}
 		ight_info("handle_resolve - family %s", _family);
-		error = self->pflist->append(_family);
+		error = pflist->append(_family);
 		if (error != 0) {
 			ight_warn("handle_resolve - cannot append");
 			// Oops the two vectors are not in sync anymore now
-			self->connecting = 0;
-			self->on_error(IghtError(-3));
+			connecting = 0;
+			on_error(IghtError(-3));
 			return;
 		}
 	}
 
     finally:
-	auto dns_base = ight_get_global_evdns_base();
+	if (must_resolve_ipv6) {
+		must_resolve_ipv6 = 0;
+		bool ok = resolve_internal(DNS_IPv6_AAAA);
+		if (ok)
+			return;
+		/* FALLTHROUGH */
+	}
+	if (must_resolve_ipv4) {
+		must_resolve_ipv4 = 0;
+		bool ok = resolve_internal(DNS_IPv4_A);
+		if (ok)
+			return;
+		/* FALLTHROUGH */
+	}
+	connect_next();
+}
 
-	if (self->must_resolve_ipv6) {
-		self->must_resolve_ipv6 = 0;
-		evdns_request *request = evdns_base_resolve_ipv6(dns_base,
-		    self->address, DNS_QUERY_NO_SEARCH, self->handle_resolve,
-		    self);
-		if (request != NULL)
-			return;
-		/* FALLTHROUGH */
-	}
-	if (self->must_resolve_ipv4) {
-		self->must_resolve_ipv4 = 0;
-		evdns_request *request = evdns_base_resolve_ipv4(dns_base,
-		    self->address, DNS_QUERY_NO_SEARCH, self->handle_resolve,
-		    self);
-		if (request != NULL)
-			return;
-		/* FALLTHROUGH */
-	}
-	self->connect_next();
+bool IghtConnectionState::resolve_internal(char type) {
+
+    std::string query;
+
+    if (type == DNS_IPv6_AAAA) {
+        query = "AAAA";
+    } else if (type == DNS_IPv4_A) {
+        query = "A";
+    } else {
+        return false;
+    }
+
+    try {
+        dns_request = ight::protocols::dns::Request(query, address,
+                [this, type](ight::protocols::dns::Response&& resp) {
+            handle_resolve(resp.get_evdns_status(), type,
+                    resp.get_results());
+        });
+    } catch (...) {
+        return false;  /* TODO: save the error */
+    }
+
+    return true;
 }
 
 void
@@ -379,8 +379,6 @@ IghtConnectionState::resolve(IghtConnectionState *self)
 		return;
 	}
 
-	auto dns_base = ight_get_global_evdns_base();
-
 	// Note: PF_UNSPEC6 means that we try with IPv6 first
 	if (strcmp(self->family, "PF_INET") == 0)
 		self->must_resolve_ipv4 = 1;
@@ -397,18 +395,16 @@ IghtConnectionState::resolve(IghtConnectionState *self)
 		return;
 	}
 
-	evdns_request *request;
+	bool ok = false;
 
 	if (self->must_resolve_ipv4) {
 		self->must_resolve_ipv4 = 0;
-		request = evdns_base_resolve_ipv4(dns_base, self->address,
-		    DNS_QUERY_NO_SEARCH, self->handle_resolve, self);
+		ok = self->resolve_internal(DNS_IPv4_A);
 	} else {
 		self->must_resolve_ipv6 = 0;
-		request = evdns_base_resolve_ipv6(dns_base, self->address,
-		    DNS_QUERY_NO_SEARCH, self->handle_resolve, self);
+		ok = self->resolve_internal(DNS_IPv6_AAAA);
 	}
-	if (request == NULL) {
+	if (!ok) {
 		self->connecting = 0;
 		self->on_error(IghtError(-6));
 		return;
@@ -426,6 +422,7 @@ IghtConnectionState::close(void)
 {
 	this->closing = 1;
 	this->bev.close();
+	this->dns_request.cancel();
 	if (this->reading != 0 || this->connecting != 0)
 		return;
 	delete this;

--- a/src/net/connection.h
+++ b/src/net/connection.h
@@ -29,11 +29,9 @@ struct evbuffer;
 class IghtConnectionState {
 
 	evutil_socket_t filedesc = IGHT_SOCKET_INVALID;
-	unsigned int closing = 0;
 	IghtBuffereventSocket bev;
 	ight::protocols::dns::Request dns_request;
 	unsigned int connecting = 0;
-	unsigned int reading = 0;
 	char *address = NULL;
 	char *port = NULL;
 	IghtStringVector *addrlist = NULL;
@@ -42,9 +40,6 @@ class IghtConnectionState {
 	unsigned int must_resolve_ipv4 = 0;
 	unsigned int must_resolve_ipv6 = 0;
 	ight::common::pointer::SharedPointer<IghtDelayedCall> start_connect;
-
-	// Private destructor because destruction may be delayed
-	~IghtConnectionState(void);
 
 	// Libevent callbacks
 	static void handle_read(bufferevent *, void *);
@@ -65,6 +60,8 @@ class IghtConnectionState {
 	IghtConnectionState& operator=(IghtConnectionState&) = delete;
 	IghtConnectionState(IghtConnectionState&&) = delete;
 	IghtConnectionState& operator=(IghtConnectionState&&) = delete;
+
+	~IghtConnectionState(void);
 
 	std::function<void(void)> on_connect = [](void) {
 		/* nothing */
@@ -151,10 +148,7 @@ class IghtConnection : public ight::common::constraints::NonCopyable,
 	}
 
 	void close(void) {
-		if (state == NULL)
-			return;
 		state->close();
-		state = NULL;		/* Idempotent */
 	}
 
 	~IghtConnection(void) {

--- a/src/net/connection.h
+++ b/src/net/connection.h
@@ -26,10 +26,18 @@
 struct IghtStringVector;
 struct evbuffer;
 
-class IghtConnectionState {
+namespace ight {
+namespace net {
+namespace connection {
+
+using namespace ight::common::constraints;
+using namespace ight::common::pointer;
+using namespace ight::protocols;
+
+class ConnectionState {
 
 	IghtBuffereventSocket bev;
-	ight::protocols::dns::Request dns_request;
+	dns::Request dns_request;
 	unsigned int connecting = 0;
 	char *address = NULL;
 	char *port = NULL;
@@ -38,7 +46,7 @@ class IghtConnectionState {
 	IghtStringVector *pflist = NULL;
 	unsigned int must_resolve_ipv4 = 0;
 	unsigned int must_resolve_ipv6 = 0;
-	ight::common::pointer::SharedPointer<IghtDelayedCall> start_connect;
+	SharedPointer<IghtDelayedCall> start_connect;
 
 	// Libevent callbacks
 	static void handle_read(bufferevent *, void *);
@@ -48,7 +56,7 @@ class IghtConnectionState {
 	// Functions used when connecting
 	void connect_next(void);
 	void handle_resolve(int, char, std::vector<std::string>);
-	static void resolve(IghtConnectionState *);
+	static void resolve(ConnectionState *);
 	bool resolve_internal(char);
 
 	std::function<void(void)> on_connect_fn = [](void) {
@@ -72,15 +80,15 @@ class IghtConnectionState {
 	};
 
     public:
-	IghtConnectionState(const char *, const char *, const char *,
+	ConnectionState(const char *, const char *, const char *,
 	    evutil_socket_t = IGHT_SOCKET_INVALID);
 
-	IghtConnectionState(IghtConnectionState&) = delete;
-	IghtConnectionState& operator=(IghtConnectionState&) = delete;
-	IghtConnectionState(IghtConnectionState&&) = delete;
-	IghtConnectionState& operator=(IghtConnectionState&&) = delete;
+	ConnectionState(ConnectionState&) = delete;
+	ConnectionState& operator=(ConnectionState&) = delete;
+	ConnectionState(ConnectionState&&) = delete;
+	ConnectionState& operator=(ConnectionState&&) = delete;
 
-	~IghtConnectionState(void);
+	~ConnectionState(void);
 
 	void on_connect(std::function<void(void)>&& fn) {
 		on_connect_fn = std::move(fn);
@@ -160,21 +168,20 @@ class IghtConnectionState {
 	void close(void);
 };
 
-class IghtConnection : public ight::common::constraints::NonCopyable,
-		public ight::common::constraints::NonMovable {
+class Connection : public NonCopyable, public NonMovable {
 
-	IghtConnectionState *state = NULL;
+	ConnectionState *state = NULL;
 
     public:
-	IghtConnection(void) {
+	Connection(void) {
 		/* nothing to do */
 	}
-	IghtConnection(evutil_socket_t fd) {
-		state = new IghtConnectionState("PF_UNSPEC", "0.0.0.0",
+	Connection(evutil_socket_t fd) {
+		state = new ConnectionState("PF_UNSPEC", "0.0.0.0",
 		    "0", fd);
 	}
-	IghtConnection(const char *af, const char *a, const char *p) {
-		state = new IghtConnectionState(af, a, p);
+	Connection(const char *af, const char *a, const char *p) {
+		state = new ConnectionState(af, a, p);
 	}
 
 	void close(void) {
@@ -183,7 +190,7 @@ class IghtConnection : public ight::common::constraints::NonCopyable,
 		state->close();
 	}
 
-	~IghtConnection(void) {
+	~Connection(void) {
 		delete state;  /* delete handles NULL */
 	}
 
@@ -272,5 +279,6 @@ class IghtConnection : public ight::common::constraints::NonCopyable,
 	}
 };
 
+}}}
 # endif  /* __cplusplus */
 #endif  /* LIBIGHT_NET_CONNECTION_H */

--- a/src/net/connection.h
+++ b/src/net/connection.h
@@ -27,8 +27,8 @@ struct evbuffer;
 class IghtConnectionState {
 
 	evutil_socket_t filedesc = IGHT_SOCKET_INVALID;
-	bufferevent *bev = NULL;
 	unsigned int closing = 0;
+	IghtBuffereventSocket bev;
 	unsigned int connecting = 0;
 	unsigned int reading = 0;
 	char *address = NULL;

--- a/src/net/connection.h
+++ b/src/net/connection.h
@@ -15,6 +15,8 @@
 #include "common/poller.h"
 #include "common/utils.hpp"
 
+#include "protocols/dns.hpp"
+
 #include <event2/bufferevent.h>
 #include <event2/event.h>
 
@@ -29,6 +31,7 @@ class IghtConnectionState {
 	evutil_socket_t filedesc = IGHT_SOCKET_INVALID;
 	unsigned int closing = 0;
 	IghtBuffereventSocket bev;
+	ight::protocols::dns::Request dns_request;
 	unsigned int connecting = 0;
 	unsigned int reading = 0;
 	char *address = NULL;
@@ -50,9 +53,9 @@ class IghtConnectionState {
 
 	// Functions used when connecting
 	void connect_next(void);
-	static void handle_resolve(int, char, int, int,
-	    void *, void *);
+	void handle_resolve(int, char, std::vector<std::string>);
 	static void resolve(IghtConnectionState *);
+	bool resolve_internal(char);
 
     public:
 	IghtConnectionState(const char *, const char *, const char *,

--- a/src/net/connection.h
+++ b/src/net/connection.h
@@ -28,7 +28,6 @@ struct evbuffer;
 
 class IghtConnectionState {
 
-	evutil_socket_t filedesc = IGHT_SOCKET_INVALID;
 	IghtBuffereventSocket bev;
 	ight::protocols::dns::Request dns_request;
 	unsigned int connecting = 0;
@@ -84,7 +83,7 @@ class IghtConnectionState {
 	};
 
 	evutil_socket_t get_fileno(void) {
-		return (this->filedesc);
+		return (bufferevent_getfd(this->bev));
 	}
 
 	int set_timeout(double timeout) {

--- a/src/net/connection.h
+++ b/src/net/connection.h
@@ -92,6 +92,7 @@ class IghtConnectionState {
 
 	void on_data(std::function<void(evbuffer *)>&& fn) {
 		on_data_fn = std::move(fn);
+		enable_read();
 	};
 
 	void on_flush(std::function<void(void)>&& fn) {

--- a/src/net/connection.h
+++ b/src/net/connection.h
@@ -106,44 +106,57 @@ class IghtConnectionState {
 		return (bufferevent_getfd(this->bev));
 	}
 
-	int set_timeout(double timeout) {
+	void set_timeout(double timeout) {
 		struct timeval tv, *tvp;
 		tvp = ight_timeval_init(&tv, timeout);
-		return (bufferevent_set_timeouts(this->bev, tvp, tvp));
+		if (bufferevent_set_timeouts(this->bev, tvp, tvp) != 0) {
+			throw std::runtime_error("cannot set timeout");
+		}
 	}
 
-	int clear_timeout(void) {
-		return (this->set_timeout(-1));
+	void clear_timeout(void) {
+		this->set_timeout(-1);
 	}
 
-	int start_tls(unsigned int) {
-		return (-1);		/* TODO: implement */
+	void start_tls(unsigned int) {
+		throw std::runtime_error("not implemented");
 	}
 
-	int write(const char *base, size_t count) {
-		if (base == NULL || count == 0)
-			return (-1);
-		return (bufferevent_write(this->bev, base, count));
+	void write(const char *base, size_t count) {
+		if (base == NULL || count == 0) {
+			throw std::runtime_error("invalid argument");
+		}
+		if (bufferevent_write(this->bev, base, count) != 0) {
+			throw std::runtime_error("cannot write");
+		}
 	}
 
-	int puts(const char *str) {
-		if (str == NULL)
-			return (-1);
-		return (this->write(str, strlen(str)));
+	void puts(const char *str) {
+		if (str == NULL) {
+			throw std::runtime_error("invalid argument");
+		}
+		this->write(str, strlen(str));
 	}
 
-	int write_from(evbuffer *sourcebuf) {
-		if (sourcebuf == NULL)
-			return (-1);
-		return (bufferevent_write_buffer(this->bev, sourcebuf));
+	void write_from(evbuffer *sourcebuf) {
+		if (sourcebuf == NULL) {
+			throw std::runtime_error("invalid argument");
+		}
+		if (bufferevent_write_buffer(this->bev, sourcebuf) != 0) {
+			throw std::runtime_error("cannot write");
+		}
 	}
 
-	int enable_read(void) {
-		return (bufferevent_enable(this->bev, EV_READ));
+	void enable_read(void) {
+		if (bufferevent_enable(this->bev, EV_READ) != 0) {
+			throw std::runtime_error("cannot enable read");
+		}
 	}
 
-	int disable_read(void) {
-		return (bufferevent_disable(this->bev, EV_READ));
+	void disable_read(void) {
+		if (bufferevent_disable(this->bev, EV_READ) != 0) {
+			throw std::runtime_error("cannot disable read");
+		}
 	}
 
 	void close(void);
@@ -212,52 +225,52 @@ class IghtConnection : public ight::common::constraints::NonCopyable,
 		return (state->get_fileno());
 	}
 
-	int set_timeout(double timeout) {
+	void set_timeout(double timeout) {
 		if (state == NULL)
 			throw std::runtime_error("Invalid state");
-		return (state->set_timeout(timeout));
+		state->set_timeout(timeout);
 	}
 
-	int clear_timeout(void) {
+	void clear_timeout(void) {
 		if (state == NULL)
 			throw std::runtime_error("Invalid state");
-		return (state->clear_timeout());
+		state->clear_timeout();
 	}
 
-	int start_tls(unsigned int d) {
+	void start_tls(unsigned int d) {
 		if (state == NULL)
 			throw std::runtime_error("Invalid state");
-		return (state->start_tls(d));
+		state->start_tls(d);
 	}
 
-	int write(const char *base, size_t count) {
+	void write(const char *base, size_t count) {
 		if (state == NULL)
 			throw std::runtime_error("Invalid state");
-		return (state->write(base, count));
+		state->write(base, count);
 	}
 
-	int puts(const char *str) {
+	void puts(const char *str) {
 		if (state == NULL)
 			throw std::runtime_error("Invalid state");
-		return (state->puts(str));
+		state->puts(str);
 	}
 
-	int write_from(evbuffer *sourcebuf) {
+	void write_from(evbuffer *sourcebuf) {
 		if (state == NULL)
 			throw std::runtime_error("Invalid state");
-		return (state->write_from(sourcebuf));
+		state->write_from(sourcebuf);
 	}
 
-	int enable_read(void) {
+	void enable_read(void) {
 		if (state == NULL)
 			throw std::runtime_error("Invalid state");
-		return (state->enable_read());
+		state->enable_read();
 	}
 
-	int disable_read(void) {
+	void disable_read(void) {
 		if (state == NULL)
 			throw std::runtime_error("Invalid state");
-		return (state->disable_read());
+		state->disable_read();
 	}
 };
 

--- a/src/net/connection.h
+++ b/src/net/connection.h
@@ -51,6 +51,26 @@ class IghtConnectionState {
 	static void resolve(IghtConnectionState *);
 	bool resolve_internal(char);
 
+	std::function<void(void)> on_connect_fn = [](void) {
+		/* nothing */
+	};
+
+	std::function<void(void)> on_ssl_fn = [](void) {
+		/* nothing */
+	};
+
+	std::function<void(evbuffer *)> on_data_fn = [](evbuffer *) {
+		/* nothing */
+	};
+
+	std::function<void(void)> on_flush_fn = [](void) {
+		/* nothing */
+	};
+
+	std::function<void(IghtError)> on_error_fn = [](IghtError) {
+		/* nothing */
+	};
+
     public:
 	IghtConnectionState(const char *, const char *, const char *,
 	    evutil_socket_t = IGHT_SOCKET_INVALID);
@@ -62,24 +82,24 @@ class IghtConnectionState {
 
 	~IghtConnectionState(void);
 
-	std::function<void(void)> on_connect = [](void) {
-		/* nothing */
+	void on_connect(std::function<void(void)>&& fn) {
+		on_connect_fn = std::move(fn);
 	};
 
-	std::function<void(void)> on_ssl = [](void) {
-		/* nothing */
+	void on_ssl(std::function<void(void)>&& fn) {
+		on_ssl_fn = std::move(fn);
 	};
 
-	std::function<void(evbuffer *)> on_data = [](evbuffer *) {
-		/* nothing */
+	void on_data(std::function<void(evbuffer *)>&& fn) {
+		on_data_fn = std::move(fn);
 	};
 
-	std::function<void(void)> on_flush = [](void) {
-		/* nothing */
+	void on_flush(std::function<void(void)>&& fn) {
+		on_flush_fn = std::move(fn);
 	};
 
-	std::function<void(IghtError)> on_error = [](IghtError) {
-		/* nothing */
+	void on_error(std::function<void(IghtError)>&& fn) {
+		on_error_fn = std::move(fn);
 	};
 
 	evutil_socket_t get_fileno(void) {
@@ -159,31 +179,31 @@ class IghtConnection : public ight::common::constraints::NonCopyable,
 	void on_connect(std::function<void(void)>&& fn) {
 		if (state == NULL)
 			throw std::runtime_error("Invalid state");
-		state->on_connect = std::move(fn);
+		state->on_connect(std::move(fn));
 	};
 
 	void on_ssl(std::function<void(void)>&& fn) {
 		if (state == NULL)
 			throw std::runtime_error("Invalid state");
-		state->on_ssl = std::move(fn);
+		state->on_ssl(std::move(fn));
 	};
 
 	void on_data(std::function<void(evbuffer *)>&& fn) {
 		if (state == NULL)
 			throw std::runtime_error("Invalid state");
-		state->on_data = std::move(fn);
+		state->on_data(std::move(fn));
 	};
 
 	void on_flush(std::function<void(void)>&& fn) {
 		if (state == NULL)
 			throw std::runtime_error("Invalid state");
-		state->on_flush = std::move(fn);
+		state->on_flush(std::move(fn));
 	};
 
 	void on_error(std::function<void(IghtError)>&& fn) {
 		if (state == NULL)
 			throw std::runtime_error("Invalid state");
-		state->on_error = std::move(fn);
+		state->on_error(std::move(fn));
 	};
 
 	evutil_socket_t get_fileno(void) {

--- a/src/net/connection.h
+++ b/src/net/connection.h
@@ -149,14 +149,12 @@ class IghtConnection : public ight::common::constraints::NonCopyable,
 
 	void close(void) {
 		if (state == NULL)
-			return;
+			throw std::runtime_error("Invalid state");
 		state->close();
-		delete state;
-		state = NULL;		/* Idempotent */
 	}
 
 	~IghtConnection(void) {
-		close();
+		delete state;  /* delete handles NULL */
 	}
 
 	void on_connect(std::function<void(void)>&& fn) {

--- a/src/net/connection.h
+++ b/src/net/connection.h
@@ -148,7 +148,11 @@ class IghtConnection : public ight::common::constraints::NonCopyable,
 	}
 
 	void close(void) {
+		if (state == NULL)
+			return;
 		state->close();
+		delete state;
+		state = NULL;		/* Idempotent */
 	}
 
 	~IghtConnection(void) {

--- a/src/net/connection.h
+++ b/src/net/connection.h
@@ -122,27 +122,24 @@ class IghtConnectionState {
 		throw std::runtime_error("not implemented");
 	}
 
-	void write(const char *base, size_t count) {
+	void send(const void *base, size_t count) {
 		if (base == NULL || count == 0) {
 			throw std::runtime_error("invalid argument");
 		}
-		if (bufferevent_write(this->bev, base, count) != 0) {
+		if (bufferevent_write(bev, base, count) != 0) {
 			throw std::runtime_error("cannot write");
 		}
 	}
 
-	void puts(const char *str) {
-		if (str == NULL) {
-			throw std::runtime_error("invalid argument");
-		}
-		this->write(str, strlen(str));
+	void send(std::string data) {
+		send(data.c_str(), data.length());
 	}
 
-	void write_from(evbuffer *sourcebuf) {
-		if (sourcebuf == NULL) {
+	void send(evbuffer *data) {
+		if (data == NULL) {
 			throw std::runtime_error("invalid argument");
 		}
-		if (bufferevent_write_buffer(this->bev, sourcebuf) != 0) {
+		if (bufferevent_write_buffer(bev, data) != 0) {
 			throw std::runtime_error("cannot write");
 		}
 	}
@@ -243,22 +240,22 @@ class IghtConnection : public ight::common::constraints::NonCopyable,
 		state->start_tls(d);
 	}
 
-	void write(const char *base, size_t count) {
+	void send(const char *base, size_t count) {
 		if (state == NULL)
 			throw std::runtime_error("Invalid state");
-		state->write(base, count);
+		state->send(base, count);
 	}
 
-	void puts(const char *str) {
+	void send(std::string str) {
 		if (state == NULL)
 			throw std::runtime_error("Invalid state");
-		state->puts(str);
+		state->send(str);
 	}
 
-	void write_from(evbuffer *sourcebuf) {
+	void send(evbuffer *sourcebuf) {
 		if (state == NULL)
 			throw std::runtime_error("Invalid state");
-		state->write_from(sourcebuf);
+		state->send(sourcebuf);
 	}
 
 	void enable_read(void) {

--- a/src/net/connection.hpp
+++ b/src/net/connection.hpp
@@ -5,9 +5,8 @@
  * information on the copying conditions.
  */
 
-#ifndef LIBIGHT_NET_CONNECTION_H
-# define LIBIGHT_NET_CONNECTION_H
-# ifdef __cplusplus
+#ifndef LIBIGHT_NET_CONNECTION_HPP
+# define LIBIGHT_NET_CONNECTION_HPP
 
 #include "common/constraints.hpp"
 #include "common/error.h"
@@ -286,6 +285,5 @@ class Connection : public NonCopyable, public NonMovable {
 	}
 };
 
-}}}
-# endif  /* __cplusplus */
-#endif  /* LIBIGHT_NET_CONNECTION_H */
+}}}  // namespaces
+#endif  /* LIBIGHT_NET_CONNECTION_HPP */

--- a/src/net/include.am
+++ b/src/net/include.am
@@ -1,6 +1,7 @@
 noinst_LTLIBRARIES += src/net/libnet.la
 
 src_net_libnet_la_SOURCES = \
+	src/net/buffer.cpp \
 	src/net/connection.cpp
 
 libight_la_LIBADD += src/net/libnet.la

--- a/src/net/include.am
+++ b/src/net/include.am
@@ -3,6 +3,7 @@ noinst_LTLIBRARIES += src/net/libnet.la
 src_net_libnet_la_SOURCES = \
 	src/net/buffer.cpp \
 	src/net/connection.cpp \
-	src/net/socks5.cpp
+	src/net/socks5.cpp \
+	src/net/transport.cpp
 
 libight_la_LIBADD += src/net/libnet.la

--- a/src/net/include.am
+++ b/src/net/include.am
@@ -2,6 +2,7 @@ noinst_LTLIBRARIES += src/net/libnet.la
 
 src_net_libnet_la_SOURCES = \
 	src/net/buffer.cpp \
-	src/net/connection.cpp
+	src/net/connection.cpp \
+	src/net/socks5.cpp
 
 libight_la_LIBADD += src/net/libnet.la

--- a/src/net/socks5.cpp
+++ b/src/net/socks5.cpp
@@ -1,0 +1,163 @@
+/*-
+ * This file is part of Libight <https://libight.github.io/>.
+ *
+ * Libight is free software. See AUTHORS and LICENSE for more
+ * information on the copying conditions.
+ */
+
+#include "net/socks5.hpp"
+
+using namespace ight::net::connection;
+using namespace ight::net::socks5;
+
+Socks5::Socks5(Settings s) : settings(s) {
+
+    ight_debug("socks5: connecting to Tor at %s:%s",
+        settings["socks5_address"].c_str(),
+        settings["socks5_port"].c_str());
+
+    conn = std::make_shared<Connection>(settings["family"].c_str(),
+        settings["socks5_address"].c_str(), settings["socks5_port"].c_str());
+
+    // Step #0: Steal "connect" and "flush" handlers
+
+    conn->on_connect([this]() {
+        conn->on_flush([]() {
+            // Nothing
+        });
+
+        // Step #1: send out preferred authentication methods
+
+        ight_debug("socks5: connected to Tor!");
+
+        IghtBuffer out;
+        out.write_uint8(5);           // Version
+        out.write_uint8(1);           // Number of methods
+        out.write_uint8(0);           // "NO_AUTH" meth.
+        conn->send(out);
+
+        ight_debug("socks5: >> version=5");
+        ight_debug("socks5: >> number of methods=1");
+        ight_debug("socks5: >> NO_AUTH (0)");
+
+        // Step #2: receive the allowed authentication methods
+
+        conn->on_data([this](SharedPointer<IghtBuffer> d) {
+            *buffer << *d;
+            auto readbuf = buffer->readn(2);
+            if (readbuf == "") {
+                return;  // Try again after next recv()
+            }
+
+            ight_debug("socks5: << version=%d", readbuf[0]);
+            ight_debug("socks5: << auth=%d", readbuf[1]);
+
+            if (readbuf[0] != 5 ||   // Reply version
+                readbuf[1] != 0) {   // Preferred auth method
+                throw std::runtime_error("generic error");
+            }
+
+            // Step #3: ask Tor to connect to remote host
+
+            IghtBuffer out;
+            out.write_uint8(5);      // Version
+            out.write_uint8(1);      // CMD_CONNECT
+            out.write_uint8(0);      // Reserved
+            out.write_uint8(3);      // ATYPE_DOMAINNAME
+
+            ight_debug("socks5: >> version=5");
+            ight_debug("socks5: >> CMD_CONNECT (0)");
+            ight_debug("socks5: >> Reserved (0)");
+            ight_debug("socks5: >> ATYPE_DOMAINNAME (3)");
+
+            auto address = settings["address"];
+
+            if (address.length() > 255) {
+                throw std::runtime_error("generic error");
+            }
+            out.write_uint8(address.length());              // Len
+            out.write(address.c_str(), address.length());  // String
+
+            ight_debug("socks5: >> domain len=%d",
+		    (uint8_t) address.length());
+            ight_debug("socks5: >> domain str=%s", address.c_str());
+
+            auto portnum = std::stoi(settings["port"]);
+            if (portnum < 0 || portnum > 65535) {
+                throw std::runtime_error("generic error");
+            }
+            out.write_uint16(portnum);                       // Port
+
+            ight_debug("socks5: >> port=%d", portnum);
+
+            conn->send(out);
+
+            // Step #4: receive Tor's response
+
+            conn->on_data([this](SharedPointer<IghtBuffer> d) {
+
+                *buffer << *d;
+                if (buffer->length() < 5) {
+                    return;  // Try again after next recv()
+                }
+
+                auto peekbuf = buffer->peek(5);
+
+                ight_debug("socks5: << version=%d", peekbuf[0]);
+                ight_debug("socks5: << reply=%d", peekbuf[1]);
+                ight_debug("socks5: << reserved=%d", peekbuf[2]);
+                ight_debug("socks5: << atype=%d", peekbuf[3]);
+
+                // TODO: Here we should process peekbuf[1] more
+                // carefully to map to the error that occurred
+                // and report it correctly to the caller
+
+                if (peekbuf[0] != 5 ||             // Version
+                    peekbuf[1] != 0 ||             // Reply
+                    peekbuf[2] != 0) {             // Reserved
+                    throw std::runtime_error("generic error");
+                }
+                auto atype = peekbuf[3];           // Atype
+
+                size_t total = 4;                  // Version .. Atype size
+                if (atype == 1) {
+                    total += 4;                    // IPv4 addr size
+                } else if (atype == 3) {
+                    total += 1                     // Len size
+                          + peekbuf[4];            // String size
+                } else if (atype == 4) {
+                    total += 16;                   // IPv6 addr size
+                } else {
+                    throw std::runtime_error("generic error");
+                }
+                total += 2;                        // Port size
+                if (buffer->length() < total) {
+                    return;  // Try again after next recv()
+                }
+
+                buffer->discard(total);
+
+                //
+                // Step #5: we are now connected
+                // Restore the original hooks
+                // Tell upstream we are connected
+                // If more data, pass it up
+                //
+
+                conn->on_data([this](SharedPointer<IghtBuffer> d) {
+                    on_data_fn(d);
+                });
+                conn->on_flush([this]() {
+                    on_flush_fn();
+                });
+
+                on_connect_fn();
+
+                // Note that on_connect_fn() may have called close()
+                if (!isclosed && buffer->length() > 0) {
+                    on_data_fn(buffer);
+                }
+            });
+        });
+    });
+}

--- a/src/net/socks5.hpp
+++ b/src/net/socks5.hpp
@@ -1,0 +1,95 @@
+/*-
+ * This file is part of Libight <https://libight.github.io/>.
+ *
+ * Libight is free software. See AUTHORS and LICENSE for more
+ * information on the copying conditions.
+ */
+
+#ifndef LIBIGHT_NET_SOCKS5_HPP
+# define LIBIGHT_NET_SOCKS5_HPP
+
+#include "common/log.h"
+
+#include "net/buffer.hpp"
+#include "net/connection.hpp"
+#include "net/transport.hpp"
+
+namespace ight {
+namespace net {
+namespace socks5 {
+
+using namespace ight::common::pointer;
+using namespace ight::common;
+
+using namespace ight::net::connection;
+using namespace ight::net::transport;
+
+class Socks5 : public Transport {
+
+protected:
+    SharedPointer<Connection> conn;
+    std::function<void()> on_connect_fn;
+    std::function<void(SharedPointer<IghtBuffer>)> on_data_fn;
+    std::function<void()> on_flush_fn;
+    Settings settings;
+    SharedPointer<IghtBuffer> buffer{
+        std::make_shared<IghtBuffer>()
+    };
+    bool isclosed = false;
+
+public:
+    Socks5(Settings);
+
+    virtual void on_connect(std::function<void()> fn) override {
+        on_connect_fn = fn;
+    }
+
+    virtual void on_ssl(std::function<void()> fn) override {
+        conn->on_ssl(fn);
+    }
+
+    virtual void on_data(std::function<void(SharedPointer<
+            IghtBuffer>)> fn) override {
+        on_data_fn = fn;
+    }
+
+    virtual void on_flush(std::function<void()> fn) override {
+        on_flush_fn = fn;
+    }
+
+    virtual void on_error(std::function<void(IghtError)> fn) override {
+        conn->on_error(fn);
+    }
+
+    virtual void set_timeout(double timeout) override {
+        conn->set_timeout(timeout);
+    }
+
+    virtual void clear_timeout() override {
+        conn->clear_timeout();
+    }
+
+    virtual void send(const void* data, size_t count) override {
+        conn->send(data, count);
+    }
+
+    virtual void send(std::string data) override {
+        conn->send(data);
+    }
+
+    virtual void send(IghtBuffer& data) override {
+        conn->send(data);
+    }
+
+    virtual void send(SharedPointer<IghtBuffer> data) override {
+        conn->send(data);
+    }
+
+    virtual void close() override {
+        isclosed = true;
+        conn->close();
+    }
+};
+
+}}}
+#endif  // LIBIGHT_NET_SOCKS5_HPP

--- a/src/net/transport.cpp
+++ b/src/net/transport.cpp
@@ -1,0 +1,54 @@
+/*-
+ * This file is part of Libight <https://libight.github.io/>.
+ *
+ * Libight is free software. See AUTHORS and LICENSE for more
+ * information on the copying conditions.
+ */
+
+#include "net/connection.hpp"
+#include "net/socks5.hpp"
+#include "net/transport.hpp"
+
+namespace ight {
+namespace net {
+namespace transport {
+
+using namespace ight::common;
+using namespace ight::common::pointer;
+
+using namespace ight::net::connection;
+using namespace ight::net::socks5;
+
+SharedPointer<Transport> connect(Settings settings) {
+
+    if (settings.find("family") == settings.end()) {
+        settings["family"] = "PF_UNSPEC";
+    }
+
+    if (settings.find("address") == settings.end()) {
+        throw std::runtime_error("invalid argument");
+    }
+    if (settings.find("port") == settings.end()) {
+        throw std::runtime_error("invalid argument");
+    }
+
+    if (settings.find("socks5_proxy") != settings.end()) {
+        // Use Tor default settings: localhost and 9050
+        if (settings.find("socks5_address") == settings.end()) {
+            if (settings["family"] != "PF_INET6") {
+                settings["socks5_address"] = "127.0.0.1";
+            } else {
+                settings["socks5_address"] = "::1";
+            }
+        }
+        if (settings.find("socks5_port") == settings.end()) {
+            settings["socks5_port"] = "9050";
+        }
+        return std::make_shared<Socks5>(settings);
+    }
+
+    return std::make_shared<Connection>(settings["family"].c_str(),
+            settings["address"].c_str(), settings["port"].c_str());
+}
+
+}}}

--- a/src/net/transport.hpp
+++ b/src/net/transport.hpp
@@ -1,0 +1,62 @@
+/*-
+ * This file is part of Libight <https://libight.github.io/>.
+ *
+ * Libight is free software. See AUTHORS and LICENSE for more
+ * information on the copying conditions.
+ */
+
+#ifndef LIBIGHT_NET_TRANSPORT_HPP
+# define LIBIGHT_NET_TRANSPORT_HPP
+
+//
+// Generic transport (stream socket, SOCKSv5, etc.)
+//
+
+#include <functional>
+#include <string>
+
+#include "common/constraints.hpp"
+#include "common/error.h"
+#include "common/pointer.hpp"
+
+#include "net/buffer.hpp"
+
+namespace ight {
+namespace net {
+namespace transport {
+
+using namespace ight::common::constraints;
+using namespace ight::common::pointer;
+
+struct Transport : public NonMovable, public NonCopyable {
+
+    Transport() {}
+
+    virtual void on_connect(std::function<void()>) = 0;
+
+    virtual void on_ssl(std::function<void()>) = 0;
+
+    virtual void on_data(std::function<void(SharedPointer<IghtBuffer>)>) = 0;
+
+    virtual void on_flush(std::function<void()>) = 0;
+
+    virtual void on_error(std::function<void(IghtError)>) = 0;
+
+    virtual void set_timeout(double) = 0;
+
+    virtual void clear_timeout() = 0;
+
+    virtual void send(const void*, size_t) = 0;
+
+    virtual void send(std::string) = 0;
+
+    virtual void send(SharedPointer<IghtBuffer>) = 0;
+
+    virtual void send(IghtBuffer&) = 0;
+
+    virtual void close() = 0;
+};
+
+}}}  // namespace
+
+#endif  // LIBIGHT_NET_TRANSPORT_HPP

--- a/src/net/transport.hpp
+++ b/src/net/transport.hpp
@@ -18,6 +18,7 @@
 #include "common/constraints.hpp"
 #include "common/error.h"
 #include "common/pointer.hpp"
+#include "common/settings.hpp"
 
 #include "net/buffer.hpp"
 
@@ -27,6 +28,7 @@ namespace transport {
 
 using namespace ight::common::constraints;
 using namespace ight::common::pointer;
+using namespace ight::common;
 
 struct Transport : public NonMovable, public NonCopyable {
 
@@ -56,6 +58,8 @@ struct Transport : public NonMovable, public NonCopyable {
 
     virtual void close() = 0;
 };
+
+SharedPointer<Transport> connect(Settings);
 
 }}}  // namespace
 

--- a/src/ooni/tcp_test.cpp
+++ b/src/ooni/tcp_test.cpp
@@ -13,7 +13,7 @@ TCPTest::connect(ight::common::Settings options, std::function<void()>&& cb)
         options["host"] = "localhost";
     }
 
-    auto connection = std::make_shared<IghtConnection>("PF_UNSPEC",
+    auto connection = std::make_shared<Connection>("PF_UNSPEC",
             options["host"].c_str(), options["port"].c_str());
 
     //

--- a/src/ooni/tcp_test.hpp
+++ b/src/ooni/tcp_test.hpp
@@ -2,7 +2,7 @@
 # define LIBIGHT_OONI_DNS_TEST_HPP
 
 #include "net/buffer.hpp"
-#include "net/connection.h"
+#include "net/connection.hpp"
 
 #include "common/emitter.hpp"
 #include "common/pointer.hpp"

--- a/src/ooni/tcp_test.hpp
+++ b/src/ooni/tcp_test.hpp
@@ -16,13 +16,14 @@ namespace ooni {
 namespace tcp_test {
 
 using namespace ight::common::pointer;
+using namespace ight::net::connection;
 
 #if 0
 class TCPClient : public ight::common::emitter::EmitterVoid,
         public ight::common::emitter::Emitter<std::string>,
         public ight::common::emitter::Emitter<IghtError> {
 
-    IghtConnection connection;
+    Connection connection;
 
 public:
 
@@ -36,7 +37,7 @@ public:
     TCPClient() {}
 
     TCPClient(std::string hostname, std::string port) {
-        connection = IghtConnection("PF_UNSPEC", hostname.c_str(),
+        connection = Connection("PF_UNSPEC", hostname.c_str(),
                 port.c_str());
         connection.on_error([this](IghtError error) {
             ight_debug("tcpclient: error event");
@@ -70,7 +71,7 @@ public:
 };
 #endif
 
-typedef SharedPointer<IghtConnection> TCPClient;           /* XXX */
+typedef SharedPointer<Connection> TCPClient;           /* XXX */
 
 class TCPTest : public net_test::NetTest {
     using net_test::NetTest::NetTest;

--- a/src/protocols/http.cpp
+++ b/src/protocols/http.cpp
@@ -237,8 +237,8 @@ public:
      * \throws std::runtime_error This method throws std::runtime_error (or
      *         a class derived from it) on several error conditions.
      */
-    void feed(evbuffer *data) {
-        buffer << data;
+    void feed(SharedPointer<IghtBuffer> data) {
+        buffer << *data;
         parse();
     }
 
@@ -349,7 +349,7 @@ ResponseParser::on_end(std::function<void(void)>&& fn)
 }
 
 void
-ResponseParser::feed(evbuffer *data)
+ResponseParser::feed(SharedPointer<IghtBuffer> data)
 {
     get_impl()->feed(data);
 }

--- a/src/protocols/http.hpp
+++ b/src/protocols/http.hpp
@@ -367,7 +367,7 @@ public:
      * \returns A reference to this stream for chaining operations.
      */
     Stream& operator<<(std::string data) {
-        connection->puts(data.c_str());
+        connection->send(data);
         return *this;
     }
 

--- a/src/protocols/http.hpp
+++ b/src/protocols/http.hpp
@@ -107,7 +107,7 @@ typedef std::map<std::string, std::string> Headers;
  *
  *     auto connection = Connection(...);
  *
- *     connection.on_data([&](evbuffer *data) {
+ *     connection.on_data([&](SharedPointer<IghtBuffer> data) {
  *         parser.feed(data);
  *     });
  */
@@ -196,7 +196,7 @@ public:
      * \throws std::runtime_error This method throws std::runtime_error (or
      *         a class derived from it) on several error conditions.
      */
-    void feed(evbuffer *data);
+    void feed(SharedPointer<IghtBuffer> data);
 
     /*!
      * \brief Feed the parser.
@@ -239,7 +239,7 @@ class Stream {
     std::function<void(IghtError)> error_handler;
 
     void connection_ready(void) {
-        connection->on_data([&](evbuffer *data) {
+        connection->on_data([&](SharedPointer<IghtBuffer> data) {
             parser.feed(data);
         });
         //

--- a/src/protocols/http.hpp
+++ b/src/protocols/http.hpp
@@ -237,9 +237,7 @@ class Stream {
     std::function<void(IghtError)> error_handler;
 
     void connection_ready(void) {
-        if (connection->enable_read() != 0) {
-            throw std::runtime_error("Cannot enable read");
-        }
+        connection->enable_read();
         connection->on_data([&](evbuffer *data) {
             parser.feed(data);
         });
@@ -369,9 +367,7 @@ public:
      * \returns A reference to this stream for chaining operations.
      */
     Stream& operator<<(std::string data) {
-        if (connection->puts(data.c_str()) != 0) {
-            throw std::runtime_error("Cannot write into the connection");
-        }
+        connection->puts(data.c_str());
         return *this;
     }
 
@@ -441,9 +437,7 @@ public:
      * \param time The timeout in seconds.
      */
     void set_timeout(double timeo) {
-        if (connection->set_timeout(timeo) != 0) {
-            throw std::runtime_error("Cannot set timeout");
-        }
+        connection->set_timeout(timeo);
     }
 };
 

--- a/src/protocols/http.hpp
+++ b/src/protocols/http.hpp
@@ -23,7 +23,7 @@
 #include "common/pointer.hpp"
 
 #include "net/buffer.hpp"
-#include "net/connection.h"
+#include "net/connection.hpp"
 
 // Internally we use joyent/http-parser
 struct http_parser;

--- a/src/protocols/http.hpp
+++ b/src/protocols/http.hpp
@@ -237,7 +237,6 @@ class Stream {
     std::function<void(IghtError)> error_handler;
 
     void connection_ready(void) {
-        connection->enable_read();
         connection->on_data([&](evbuffer *data) {
             parser.feed(data);
         });

--- a/src/protocols/http.hpp
+++ b/src/protocols/http.hpp
@@ -39,6 +39,8 @@ namespace http {
 using namespace ight::common::constraints;
 using namespace ight::common::pointer;
 
+using namespace ight::net::connection;
+
 /*!
  * \brief Raised when the parser receives the UPGRADE method.
  * \remark This should not happen.
@@ -103,7 +105,7 @@ typedef std::map<std::string, std::string> Headers;
  *
  *     ...
  *
- *     auto connection = IghtConnection(...);
+ *     auto connection = Connection(...);
  *
  *     connection.on_data([&](evbuffer *data) {
  *         parser.feed(data);
@@ -232,7 +234,7 @@ public:
  * degree of control is needed over the HTTP protocol.
  */
 class Stream {
-    SharedPointer<IghtConnection> connection;
+    SharedPointer<Connection> connection;
     ResponseParser parser;
     std::function<void(IghtError)> error_handler;
 
@@ -305,7 +307,7 @@ public:
      */
     Stream(std::string address, std::string port,
             std::string family = "PF_UNSPEC") {
-        connection = std::make_shared<IghtConnection>(family.c_str(),
+        connection = std::make_shared<Connection>(family.c_str(),
                 address.c_str(), port.c_str());
         //
         // While the connection is in progress, just forward the
@@ -324,7 +326,7 @@ public:
      * \sock The already connecte socket.
      */
     Stream(evutil_socket_t sock) {
-        connection = std::make_shared<IghtConnection>(sock);
+        connection = std::make_shared<Connection>(sock);
         connection_ready();
     }
 

--- a/test/echo_client_evbuf.cpp
+++ b/test/echo_client_evbuf.cpp
@@ -10,6 +10,8 @@
 
 #include <stdlib.h>
 
+using namespace ight::common::pointer;
+
 int
 main(void)
 {
@@ -19,7 +21,7 @@ main(void)
 		/* nothing */
 	});
 
-	s.on_data([&](evbuffer *b) {
+	s.on_data([&](SharedPointer<IghtBuffer> b) {
 		s.send(b);
 	});
 

--- a/test/echo_client_evbuf.cpp
+++ b/test/echo_client_evbuf.cpp
@@ -13,7 +13,7 @@
 int
 main(void)
 {
-	IghtConnection s("PF_INET", "127.0.0.1", "54321");
+	ight::net::connection::Connection s("PF_INET", "127.0.0.1", "54321");
 
 	s.on_connect([&](void) {
 		/* nothing */

--- a/test/echo_client_evbuf.cpp
+++ b/test/echo_client_evbuf.cpp
@@ -6,7 +6,7 @@
  */
 
 #include "common/log.h"
-#include "net/connection.h"
+#include "net/connection.hpp"
 
 #include <stdlib.h>
 

--- a/test/echo_client_evbuf.cpp
+++ b/test/echo_client_evbuf.cpp
@@ -16,13 +16,11 @@ main(void)
 	IghtConnection s("PF_INET", "127.0.0.1", "54321");
 
 	s.on_connect([&](void) {
-		if (s.enable_read() != 0)
-			s.close();
+		s.enable_read();
 	});
 
 	s.on_data([&](evbuffer *b) {
-		if (s.write_from(b) != 0)
-			s.close();
+		s.write_from(b);
 	});
 
 	s.on_flush([](void) {
@@ -34,8 +32,7 @@ main(void)
 		s.close();
 	});
 
-	if (s.set_timeout(7.0) != 0)
-		exit(EXIT_FAILURE);
+	s.set_timeout(7.0);
 
 	ight_get_global_poller()->break_loop_on_sigint_();
 	ight_loop();

--- a/test/echo_client_evbuf.cpp
+++ b/test/echo_client_evbuf.cpp
@@ -20,7 +20,7 @@ main(void)
 	});
 
 	s.on_data([&](evbuffer *b) {
-		s.write_from(b);
+		s.send(b);
 	});
 
 	s.on_flush([](void) {

--- a/test/echo_client_evbuf.cpp
+++ b/test/echo_client_evbuf.cpp
@@ -16,7 +16,7 @@ main(void)
 	IghtConnection s("PF_INET", "127.0.0.1", "54321");
 
 	s.on_connect([&](void) {
-		s.enable_read();
+		/* nothing */
 	});
 
 	s.on_data([&](evbuffer *b) {

--- a/test/net/connection.cpp
+++ b/test/net/connection.cpp
@@ -6,7 +6,7 @@
  */
 
 //
-// Tests for src/net/connection.h's IghtConnection{State,}
+// Tests for src/net/connection.h's Connection{State,}
 //
 
 #define CATCH_CONFIG_MAIN
@@ -17,22 +17,24 @@
 
 #include "net/connection.h"
 
+using namespace ight::net::connection;
+
 TEST_CASE("Ensure that the constructor socket-validity checks work") {
 
 	SECTION("Invalid values are properly normalized") {
 		{
 			/* Common for both Unix and Windows */
-			IghtConnection conn(-1);
+			Connection conn(-1);
 			REQUIRE(conn.get_fileno() == -1);
 		}
 #ifndef WIN32
 		{
-			IghtConnection conn(-2);
+			Connection conn(-2);
 			REQUIRE(conn.get_fileno() == -1);
 		}
 		/* ... */
 		{
-			IghtConnection conn(INT_MIN);
+			Connection conn(INT_MIN);
 			REQUIRE(conn.get_fileno() == -1);
 		}
 #endif
@@ -40,39 +42,39 @@ TEST_CASE("Ensure that the constructor socket-validity checks work") {
 
 	SECTION("Valid values are accepted") {
 		{
-			IghtConnection conn(0);
+			Connection conn(0);
 			REQUIRE(conn.get_fileno() == 0);
 		}
 		{
-			IghtConnection conn(1);
+			Connection conn(1);
 			REQUIRE(conn.get_fileno() == 1);
 		}
 		{
-			IghtConnection conn(2);
+			Connection conn(2);
 			REQUIRE(conn.get_fileno() == 2);
 		}
 #ifdef WIN32
 		{
-			IghtConnection conn(INTPTR_MAX);
+			Connection conn(INTPTR_MAX);
 			REQUIRE(conn.get_fileno() == INTPTR_MAX);
 		}
 		/* Skip -1 that is INVALID_SOCKET */
 		{
-			IghtConnection conn(-2);
+			Connection conn(-2);
 			REQUIRE(conn.get_fileno() == -2);
 		}
 		{
-			IghtConnection conn(-3);
+			Connection conn(-3);
 			REQUIRE(conn.get_fileno() == -3);
 		}
 		/* ... */
 		{
-			IghtConnection conn(INTPTR_MIN);
+			Connection conn(INTPTR_MIN);
 			REQUIRE(conn.get_fileno() == INTPTR_MIN);
 		}
 #else
 		{
-			IghtConnection conn(INT_MAX);
+			Connection conn(INT_MAX);
 			REQUIRE(conn.get_fileno() == INT_MAX);
 		}
 
@@ -80,11 +82,11 @@ TEST_CASE("Ensure that the constructor socket-validity checks work") {
 	}
 }
 
-TEST_CASE("IghtConnection::close() is idempotent") {
+TEST_CASE("Connection::close() is idempotent") {
     if (ight::Network::is_down()) {
         return;
     }
-    IghtConnection s("PF_INET", "nexa.polito.it", "80");
+    Connection s("PF_INET", "nexa.polito.it", "80");
     s.on_connect([&s]() {
         s.enable_read();
         s.send("GET / HTTP/1.0\r\n\r\n");
@@ -99,11 +101,11 @@ TEST_CASE("IghtConnection::close() is idempotent") {
     ight_loop();
 }
 
-TEST_CASE("It is safe to manipulate IghtConnection after close") {
+TEST_CASE("It is safe to manipulate Connection after close") {
     if (ight::Network::is_down()) {
         return;
     }
-    IghtConnection s("PF_INET", "nexa.polito.it", "80");
+    Connection s("PF_INET", "nexa.polito.it", "80");
     s.on_connect([&s]() {
         s.enable_read();
         s.send("GET / HTTP/1.0\r\n\r\n");
@@ -119,12 +121,12 @@ TEST_CASE("It is safe to manipulate IghtConnection after close") {
     ight_loop();
 }
 
-TEST_CASE("It is safe to close IghtConnection while resolve is in progress") {
+TEST_CASE("It is safe to close Connection while resolve is in progress") {
     if (ight::Network::is_down()) {
         return;
     }
     ight_set_verbose(1);
-    IghtConnection s("PF_INET", "nexa.polito.it", "80");
+    Connection s("PF_INET", "nexa.polito.it", "80");
     IghtDelayedCall unsched(0.001, [&s]() {
         s.close();
     });

--- a/test/net/connection.cpp
+++ b/test/net/connection.cpp
@@ -12,6 +12,9 @@
 #define CATCH_CONFIG_MAIN
 #include "src/ext/Catch/single_include/catch.hpp"
 
+#include "common/check_connectivity.hpp"
+#include "common/log.h"
+
 #include "net/connection.h"
 
 TEST_CASE("Ensure that the constructor socket-validity checks work") {
@@ -75,4 +78,58 @@ TEST_CASE("Ensure that the constructor socket-validity checks work") {
 
 #endif
 	}
+}
+
+TEST_CASE("IghtConnection::close() is idempotent") {
+    if (ight::Network::is_down()) {
+        return;
+    }
+    IghtConnection s("PF_INET", "nexa.polito.it", "80");
+    s.on_connect([&s]() {
+        REQUIRE(s.enable_read() == 0);
+        REQUIRE(s.puts("GET / HTTP/1.0\r\n\r\n") == 0);
+    });
+    s.on_data([&s](evbuffer *) {
+        s.close();
+        // It shall be safe to call close() more than once
+        s.close();
+        s.close();
+        ight_break_loop();
+    });
+    ight_loop();
+}
+
+TEST_CASE("It is safe to manipulate IghtConnection after close") {
+    if (ight::Network::is_down()) {
+        return;
+    }
+    IghtConnection s("PF_INET", "nexa.polito.it", "80");
+    s.on_connect([&s]() {
+        REQUIRE(s.enable_read() == 0);
+        REQUIRE(s.puts("GET / HTTP/1.0\r\n\r\n") == 0);
+    });
+    s.on_data([&s](evbuffer *) {
+        s.close();
+        // It shall be safe to call any API after close()
+	// where safe means that we don't segfault
+        REQUIRE_THROWS(s.enable_read());
+        REQUIRE_THROWS(s.disable_read());
+        ight_break_loop();
+    });
+    ight_loop();
+}
+
+TEST_CASE("It is safe to close IghtConnection while resolve is in progress") {
+    if (ight::Network::is_down()) {
+        return;
+    }
+    ight_set_verbose(1);
+    IghtConnection s("PF_INET", "nexa.polito.it", "80");
+    IghtDelayedCall unsched(0.001, [&s]() {
+        s.close();
+    });
+    IghtDelayedCall bail_out(2.0, []() {
+        ight_break_loop();
+    });
+    ight_loop();
 }

--- a/test/net/connection.cpp
+++ b/test/net/connection.cpp
@@ -15,7 +15,7 @@
 #include "common/check_connectivity.hpp"
 #include "common/log.h"
 
-#include "net/connection.h"
+#include "net/connection.hpp"
 
 using namespace ight::net::connection;
 

--- a/test/net/connection.cpp
+++ b/test/net/connection.cpp
@@ -87,7 +87,7 @@ TEST_CASE("IghtConnection::close() is idempotent") {
     IghtConnection s("PF_INET", "nexa.polito.it", "80");
     s.on_connect([&s]() {
         s.enable_read();
-        s.puts("GET / HTTP/1.0\r\n\r\n");
+        s.send("GET / HTTP/1.0\r\n\r\n");
     });
     s.on_data([&s](evbuffer *) {
         s.close();
@@ -106,7 +106,7 @@ TEST_CASE("It is safe to manipulate IghtConnection after close") {
     IghtConnection s("PF_INET", "nexa.polito.it", "80");
     s.on_connect([&s]() {
         s.enable_read();
-        s.puts("GET / HTTP/1.0\r\n\r\n");
+        s.send("GET / HTTP/1.0\r\n\r\n");
     });
     s.on_data([&s](evbuffer *) {
         s.close();

--- a/test/net/connection.cpp
+++ b/test/net/connection.cpp
@@ -91,7 +91,7 @@ TEST_CASE("Connection::close() is idempotent") {
         s.enable_read();
         s.send("GET / HTTP/1.0\r\n\r\n");
     });
-    s.on_data([&s](evbuffer *) {
+    s.on_data([&s](SharedPointer<IghtBuffer>) {
         s.close();
         // It shall be safe to call close() more than once
         s.close();
@@ -110,7 +110,7 @@ TEST_CASE("It is safe to manipulate Connection after close") {
         s.enable_read();
         s.send("GET / HTTP/1.0\r\n\r\n");
     });
-    s.on_data([&s](evbuffer *) {
+    s.on_data([&s](SharedPointer<IghtBuffer>) {
         s.close();
         // It shall be safe to call any API after close()
 	// where safe means that we don't segfault

--- a/test/net/connection.cpp
+++ b/test/net/connection.cpp
@@ -86,8 +86,8 @@ TEST_CASE("IghtConnection::close() is idempotent") {
     }
     IghtConnection s("PF_INET", "nexa.polito.it", "80");
     s.on_connect([&s]() {
-        REQUIRE(s.enable_read() == 0);
-        REQUIRE(s.puts("GET / HTTP/1.0\r\n\r\n") == 0);
+        s.enable_read();
+        s.puts("GET / HTTP/1.0\r\n\r\n");
     });
     s.on_data([&s](evbuffer *) {
         s.close();
@@ -105,8 +105,8 @@ TEST_CASE("It is safe to manipulate IghtConnection after close") {
     }
     IghtConnection s("PF_INET", "nexa.polito.it", "80");
     s.on_connect([&s]() {
-        REQUIRE(s.enable_read() == 0);
-        REQUIRE(s.puts("GET / HTTP/1.0\r\n\r\n") == 0);
+        s.enable_read();
+        s.puts("GET / HTTP/1.0\r\n\r\n");
     });
     s.on_data([&s](evbuffer *) {
         s.close();


### PR DESCRIPTION
This is done by introducing Transport, a new abstraction, from which both socks5 and the old connection derive. Then, when you create a transport, you can specify whether to use socks5 or not. Depending on your choice, the connection code or the socks5 code is picked up.