### PR TITLE
Fixes for src/ooni headers

### DIFF
--- a/src/ooni/http_test.hpp
+++ b/src/ooni/http_test.hpp
@@ -1,5 +1,5 @@
-#ifndef LIBIGHT_OONI_DNS_TEST_HPP
-# define LIBIGHT_OONI_DNS_TEST_HPP
+#ifndef LIBIGHT_OONI_HTTP_TEST_HPP
+# define LIBIGHT_OONI_HTTP_TEST_HPP
 
 #include "common/settings.hpp"
 #include "protocols/http.hpp"

--- a/src/ooni/net_test.hpp
+++ b/src/ooni/net_test.hpp
@@ -110,7 +110,7 @@ public:
 
   NetTest(void);
 
-  ~NetTest(void);
+  virtual ~NetTest(void);
 
   NetTest(NetTest&) = delete;
   NetTest& operator=(NetTest&) = delete;

--- a/src/ooni/net_test.hpp
+++ b/src/ooni/net_test.hpp
@@ -1,5 +1,5 @@
-#ifndef LIBIGHT_OONI_NETTEST_HPP
-# define LIBIGHT_OONI_NETTEST_HPP
+#ifndef LIBIGHT_OONI_NET_TEST_HPP
+# define LIBIGHT_OONI_NET_TEST_HPP
 
 #include <iterator>
 #include <iostream>
@@ -138,4 +138,4 @@ public:
 
 }}}
 
-#endif  // LIBIGHT_OONI_NETTEST_HPP
+#endif  // LIBIGHT_OONI_NET_TEST_HPP

--- a/src/ooni/tcp_test.hpp
+++ b/src/ooni/tcp_test.hpp
@@ -1,5 +1,5 @@
-#ifndef LIBIGHT_OONI_DNS_TEST_HPP
-# define LIBIGHT_OONI_DNS_TEST_HPP
+#ifndef LIBIGHT_OONI_TCP_TEST_HPP
+# define LIBIGHT_OONI_TCP_TEST_HPP
 
 #include "net/buffer.hpp"
 #include "net/connection.hpp"


### PR DESCRIPTION
Stuff spotted while working on another branch:

1) make sure headers have distinct include guards so that all headers can be successfully included by the same source file;

2) make `NetTest` destructor virtual to avoid a compiler warning.