### PR TITLE
Plug memleak in src/protocols/http.hpp

### DIFF
--- a/src/protocols/http.hpp
+++ b/src/protocols/http.hpp
@@ -236,6 +236,7 @@ class Stream {
     SharedPointer<Transport> connection;
     ResponseParser parser;
     std::function<void(IghtError)> error_handler;
+    std::function<void()> connect_handler;
 
     void connection_ready(void) {
         connection->on_data([&](SharedPointer<IghtBuffer> data) {
@@ -253,6 +254,7 @@ class Stream {
                 error_handler(error);
             }
         });
+        connect_handler();
     }
 
 public:
@@ -319,9 +321,9 @@ public:
      *         object attaching it to an already opened socket.
      */
     void on_connect(std::function<void(void)>&& fn) {
-        connection->on_connect([fn, this]() {
+        connect_handler = fn;
+        connection->on_connect([this]() {
             connection_ready();
-            fn();
         });
     }
 


### PR DESCRIPTION
Apparently (but, to be honest, I don't fully understand why) it is not safe to pass a function in the closure of another function.

That is, the safest patter that we should use is to pass only `this` into the closure of a callback.

Before this commit:

    $ valgrind --leak-check=full ./test/protocols/http "HTTP stream works as expected"
    ==24200== Memcheck, a memory error detector
    ==24200== Copyright (C) 2002-2013, and GNU GPL'd, by Julian Seward et al.
    ==24200== Using Valgrind-3.10.0.SVN and LibVEX; rerun with -h for copyright info
    ==24200== Command: ./test/protocols/http HTTP\ stream\ works\ as\ expected
    ==24200==

    ===============================================================================
    test cases: 1 | 1 passed
    assertions: - none -

    ==24200==
    ==24200== HEAP SUMMARY:
    ==24200==     in use at exit: 8 bytes in 1 blocks
    ==24200==   total heap usage: 870 allocs, 869 frees, 95,586 bytes allocated
    ==24200==
    ==24200== 8 bytes in 1 blocks are definitely lost in loss record 1 of 1
    ==24200==    at 0x4C2B0E0: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
    ==24200==    by 0x419FB2: std::_Function_base::_Base_manager<____C_A_T_C_H____T_E_S_T____117()::$_6>::_M_manager(std::_Any_data&, std::_Any_data const&, std::_Manager_operation) (functional:1910)
    ==24200==    by 0x4391BC: ight::protocols::http::Stream::on_connect(std::function<void ()>&&) (functional:2437)
    ==24200==    by 0x41111C: ____C_A_T_C_H____T_E_S_T____117() (http.cpp:126)
    ==24200==    by 0x443CDD: Catch::RunContext::runCurrentTest(std::string&, std::string&) (catch.hpp:6389)
    ==24200==    by 0x44021D: Catch::RunContext::runTest(Catch::TestCase const&) (catch.hpp:5001)
    ==24200==    by 0x43F184: Catch::Runner::runTests() (catch.hpp:5275)
    ==24200==    by 0x43E8D5: Catch::Session::run() (catch.hpp:5395)
    ==24200==    by 0x41072E: main (catch.hpp:5377)
    ==24200==
    ==24200== LEAK SUMMARY:
    ==24200==    definitely lost: 8 bytes in 1 blocks
    ==24200==    indirectly lost: 0 bytes in 0 blocks
    ==24200==      possibly lost: 0 bytes in 0 blocks
    ==24200==    still reachable: 0 bytes in 0 blocks
    ==24200==         suppressed: 0 bytes in 0 blocks
    ==24200==
    ==24200== For counts of detected and suppressed errors, rerun with: -v
    ==24200== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)

After this commit:

    $ valgrind --leak-check=full ./test/protocols/http "HTTP stream works as expected"
    ==25348== Memcheck, a memory error detector
    ==25348== Copyright (C) 2002-2013, and GNU GPL'd, by Julian Seward et al.
    ==25348== Using Valgrind-3.10.0.SVN and LibVEX; rerun with -h for copyright info
    ==25348== Command: ./test/protocols/http HTTP\ stream\ works\ as\ expected
    ==25348==

    ===============================================================================
    test cases: 1 | 1 passed
    assertions: - none -

    ==25348==
    ==25348== HEAP SUMMARY:
    ==25348==     in use at exit: 0 bytes in 0 blocks
    ==25348==   total heap usage: 870 allocs, 870 frees, 95,522 bytes allocated
    ==25348==
    ==25348== All heap blocks were freed -- no leaks are possible
    ==25348==
    ==25348== For counts of detected and suppressed errors, rerun with: -v
    ==25348== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)