### PR TITLE
Plug all memory leaks in dns_injection

### DIFF
--- a/src/ooni/dns_injection.cpp
+++ b/src/ooni/dns_injection.cpp
@@ -8,8 +8,9 @@ DNSInjection::main(std::string input, ight::common::Settings options,
                    std::function<void(ReportEntry)>&& cb)
 {
     entry["injected"] = NULL;
+    have_entry = cb;
     query(QueryType::A, QueryClass::IN,
-                   input, options["nameserver"], [=](
+                   input, options["nameserver"], [this](
                               protocols::dns::Response&& response) {
         ight_debug("Got response to DNS Injection test");
         if (response.get_evdns_status() == DNS_ERR_NONE) {
@@ -17,6 +18,6 @@ DNSInjection::main(std::string input, ight::common::Settings options,
         } else {
             entry["injected"] = false;
         }
-        cb(entry);
+        have_entry(entry);
     });
 }

--- a/src/ooni/dns_injection.hpp
+++ b/src/ooni/dns_injection.hpp
@@ -23,6 +23,8 @@ class InputFileRequired : public std::runtime_error {
 class DNSInjection : public DNSTest {
     using DNSTest::DNSTest;
 
+    std::function<void(ReportEntry)> have_entry;
+
 public:
     DNSInjection(std::string input_filepath_, ight::common::Settings options_) : 
       DNSTest(input_filepath_, options_) {


### PR DESCRIPTION
Following up from #77. My understanding is now slightly increased: it's not that passing `std::function<>` as lambad's `[]` context is something that, in general, causes memory leaks. This only happens in some cases. For example, in this case to plug the leak it was enough to fix DNS injection usage of lambdas, without touching `net_test.cpp`.

Before this commit:

    ==28014== Memcheck, a memory error detector
    ==28014== Copyright (C) 2002-2013, and GNU GPL'd, by Julian Seward et al.
    ==28014== Using Valgrind-3.10.0.SVN and LibVEX; rerun with -h for copyright info
    ==28014== Command: ./test/ooni/dns_injection
    ==28014==
    Found input file
    Running next measurement
    Getting next line
    Returning new line
    Creating entry
    Calling setup
    Running with input torproject.org
    dns - IPv4
    dns - adding '82.195.75.101'
    dns - adding '86.59.30.40'
    dns - adding '93.95.227.222'
    dns - adding '154.35.132.70'
    dns - adding '38.229.72.16'
    Got a response!
    Callbacking
    Got response to DNS Injection test
    Tearing down
    Written entry
    Increased
    Running next measurement
    Getting next line
    Returning new line
    Creating entry
    Calling setup
    Running with input ooni.nu
    called.
    dns - IPv4
    dns - adding '162.255.119.254'
    Got a response!
    Callbacking
    Got response to DNS Injection test
    Tearing down
    Written entry
    Increased
    Running next measurement
    Getting next line
    Returning new line
    Creating entry
    Calling setup
    Running with input neubot.org
    called.
    dns - IPv4
    dns - adding '130.192.16.172'
    Got a response!
    Callbacking
    Got response to DNS Injection test
    Tearing down
    Written entry
    Increased
    Running next measurement
    Getting next line
    EOF reached.
    Reached end of input
    called.
    ===============================================================================
    All tests passed (2 assertions in 3 test cases)

    ==28014==
    ==28014== HEAP SUMMARY:
    ==28014==     in use at exit: 144 bytes in 6 blocks
    ==28014==   total heap usage: 15,034 allocs, 15,028 frees, 1,078,883 bytes allocated
    ==28014==
    ==28014== LEAK SUMMARY:
    ==28014==    definitely lost: 120 bytes in 3 blocks
    ==28014==    indirectly lost: 24 bytes in 3 blocks
    ==28014==      possibly lost: 0 bytes in 0 blocks
    ==28014==    still reachable: 0 bytes in 0 blocks
    ==28014==         suppressed: 0 bytes in 0 blocks
    ==28014== Rerun with --leak-check=full to see details of leaked memory
    ==28014==
    ==28014== For counts of detected and suppressed errors, rerun with: -v
    ==28014== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

After this commit:

    ==29674== Memcheck, a memory error detector
    ==29674== Copyright (C) 2002-2013, and GNU GPL'd, by Julian Seward et al.
    ==29674== Using Valgrind-3.10.0.SVN and LibVEX; rerun with -h for copyright info
    ==29674== Command: ./test/ooni/dns_injection
    ==29674==
    Found input file
    Running next measurement
    Getting next line
    Returning new line
    Creating entry
    Calling setup
    Running with input torproject.org
    dns - IPv4
    dns - adding '82.195.75.101'
    dns - adding '86.59.30.40'
    dns - adding '93.95.227.222'
    dns - adding '154.35.132.70'
    dns - adding '38.229.72.16'
    Got a response!
    Callbacking
    Got response to DNS Injection test
    Tearing down
    Written entry
    Increased
    Running next measurement
    Getting next line
    Returning new line
    Creating entry
    Calling setup
    Running with input ooni.nu
    called.
    dns - IPv4
    dns - adding '162.255.119.254'
    Got a response!
    Callbacking
    Got response to DNS Injection test
    Tearing down
    Written entry
    Increased
    Running next measurement
    Getting next line
    Returning new line
    Creating entry
    Calling setup
    Running with input neubot.org
    called.
    dns - IPv4
    dns - adding '130.192.16.172'
    Got a response!
    Callbacking
    Got response to DNS Injection test
    Tearing down
    Written entry
    Increased
    Running next measurement
    Getting next line
    EOF reached.
    Reached end of input
    called.
    ===============================================================================
    All tests passed (2 assertions in 3 test cases)

    ==29674==
    ==29674== HEAP SUMMARY:
    ==29674==     in use at exit: 0 bytes in 0 blocks
    ==29674==   total heap usage: 15,038 allocs, 15,038 frees, 1,079,479 bytes allocated
    ==29674==
    ==29674== All heap blocks were freed -- no leaks are possible
    ==29674==
    ==29674== For counts of detected and suppressed errors, rerun with: -v
    ==29674== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)