### PR TITLE
Fix memleak in tcp_connect

### DIFF
--- a/src/ooni/tcp_connect.cpp
+++ b/src/ooni/tcp_connect.cpp
@@ -7,8 +7,9 @@ TCPConnect::main(std::string input, ight::common::Settings options,
                  std::function<void(ReportEntry)>&& cb)
 {
     options["host"] = input;
-    client = connect(options, [=]() {
+    have_entry = cb;
+    client = connect(options, [this]() {
         ight_debug("Got response to TCP connect test");
-        cb(entry);
+        have_entry(entry);
     });
 }

--- a/src/ooni/tcp_connect.hpp
+++ b/src/ooni/tcp_connect.hpp
@@ -23,6 +23,8 @@ class TCPConnect : public TCPTest {
 
     TCPClient client;
 
+    std::function<void(ReportEntry)> have_entry;
+
 public:
     TCPConnect(std::string input_filepath_, ight::common::Settings options_) : 
       TCPTest(input_filepath_, options_) {


### PR DESCRIPTION
Following up from #77 and #78, let's plug more leaks. All these leak-plugging commits will help me to debug other memory errors that I am seeing in other branches.

Before this commit:

    ==32409== Memcheck, a memory error detector
    ==32409== Copyright (C) 2002-2013, and GNU GPL'd, by Julian Seward et al.
    ==32409== Using Valgrind-3.10.0.SVN and LibVEX; rerun with -h for copyright info
    ==32409== Command: ./test/ooni/tcp_connect
    ==32409==
    Found input file
    Running next measurement
    Getting next line
    Returning new line
    Creating entry
    Calling setup
    Running with input torproject.org
    utils:ight_timeval_init - enter
    utils:ight_timeval_init - ok
    dns - IPv4
    dns - adding '86.59.30.40'
    dns - adding '93.95.227.222'
    dns - adding '154.35.132.70'
    dns - adding '38.229.72.16'
    dns - adding '82.195.75.101'
    handle_resolve - enter
    handle_resolve - IPv4
    handle_resolve - address 86.59.30.40
    handle_resolve - family PF_INET
    handle_resolve - address 93.95.227.222
    handle_resolve - family PF_INET
    handle_resolve - address 154.35.132.70
    handle_resolve - family PF_INET
    handle_resolve - address 38.229.72.16
    handle_resolve - family PF_INET
    handle_resolve - address 82.195.75.101
    handle_resolve - family PF_INET
    dns - IPv6
    dns - adding '2001:858:2:2:aabb:0:563b:1e28'
    dns - adding '2001:41b8:202:deb:213:21ff:fe20:1426'
    dns - adding '2620:0:6b0:b:1a1a:0:26e5:4810'
    handle_resolve - enter
    handle_resolve - IPv6
    handle_resolve - address 2001:858:2:2:aabb:0:563b:1e28
    handle_resolve - family PF_INET6
    handle_resolve - address 2001:41b8:202:deb:213:21ff:fe20:1426
    handle_resolve - family PF_INET6
    handle_resolve - address 2620:0:6b0:b:1a1a:0:26e5:4810
    handle_resolve - family PF_INET6
    connect_next - enter
    connect_next - PF_INET 86.59.30.40
    utils:ight_storage_init - enter
    utils:ight_storage_init - ok
    utils:ight_socket - enter
    utils:ight_socket - ok
    connect_next - ok
    Got response to TCP connect test
    Tearing down
    Written entry
    Increased
    Running next measurement
    Getting next line
    Returning new line
    Creating entry
    Calling setup
    Running with input ooni.nu
    utils:ight_timeval_init - enter
    utils:ight_timeval_init - ok
    dns - IPv4
    dns - adding '162.255.119.254'
    handle_resolve - enter
    handle_resolve - IPv4
    handle_resolve - address 162.255.119.254
    handle_resolve - family PF_INET
    dns - request failed: 70
    handle_resolve - enter
    connect_next - enter
    connect_next - PF_INET 162.255.119.254
    utils:ight_storage_init - enter
    utils:ight_storage_init - ok
    utils:ight_socket - enter
    utils:ight_socket - ok
    connect_next - ok
    Got response to TCP connect test
    Tearing down
    Written entry
    Increased
    Running next measurement
    Getting next line
    Returning new line
    Creating entry
    Calling setup
    Running with input neubot.org
    utils:ight_timeval_init - enter
    utils:ight_timeval_init - ok
    dns - IPv4
    dns - adding '130.192.16.172'
    handle_resolve - enter
    handle_resolve - IPv4
    handle_resolve - address 130.192.16.172
    handle_resolve - family PF_INET
    dns - request failed: 70
    handle_resolve - enter
    connect_next - enter
    connect_next - PF_INET 130.192.16.172
    utils:ight_storage_init - enter
    utils:ight_storage_init - ok
    utils:ight_socket - enter
    utils:ight_socket - ok
    connect_next - ok
    Got response to TCP connect test
    Tearing down
    Written entry
    Increased
    Running next measurement
    Getting next line
    EOF reached.
    Reached end of input
    ===============================================================================
    All tests passed (2 assertions in 3 test cases)

    ==32409==
    ==32409== HEAP SUMMARY:
    ==32409==     in use at exit: 144 bytes in 6 blocks
    ==32409==   total heap usage: 6,803 allocs, 6,797 frees, 494,434 bytes allocated
    ==32409==
    ==32409== LEAK SUMMARY:
    ==32409==    definitely lost: 120 bytes in 3 blocks
    ==32409==    indirectly lost: 24 bytes in 3 blocks
    ==32409==      possibly lost: 0 bytes in 0 blocks
    ==32409==    still reachable: 0 bytes in 0 blocks
    ==32409==         suppressed: 0 bytes in 0 blocks
    ==32409== Rerun with --leak-check=full to see details of leaked memory
    ==32409==
    ==32409== For counts of detected and suppressed errors, rerun with: -v
    ==32409== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

After:

    ==31153== Memcheck, a memory error detector
    ==31153== Copyright (C) 2002-2013, and GNU GPL'd, by Julian Seward et al.
    ==31153== Using Valgrind-3.10.0.SVN and LibVEX; rerun with -h for copyright info
    ==31153== Command: ./test/ooni/tcp_connect
    ==31153==
    Found input file
    Running next measurement
    Getting next line
    Returning new line
    Creating entry
    Calling setup
    Running with input torproject.org
    utils:ight_timeval_init - enter
    utils:ight_timeval_init - ok
    dns - IPv4
    dns - adding '154.35.132.70'
    dns - adding '38.229.72.16'
    dns - adding '82.195.75.101'
    dns - adding '86.59.30.40'
    dns - adding '93.95.227.222'
    handle_resolve - enter
    handle_resolve - IPv4
    handle_resolve - address 154.35.132.70
    handle_resolve - family PF_INET
    handle_resolve - address 38.229.72.16
    handle_resolve - family PF_INET
    handle_resolve - address 82.195.75.101
    handle_resolve - family PF_INET
    handle_resolve - address 86.59.30.40
    handle_resolve - family PF_INET
    handle_resolve - address 93.95.227.222
    handle_resolve - family PF_INET
    dns - IPv6
    dns - adding '2620:0:6b0:b:1a1a:0:26e5:4810'
    dns - adding '2001:41b8:202:deb:213:21ff:fe20:1426'
    dns - adding '2001:858:2:2:aabb:0:563b:1e28'
    handle_resolve - enter
    handle_resolve - IPv6
    handle_resolve - address 2620:0:6b0:b:1a1a:0:26e5:4810
    handle_resolve - family PF_INET6
    handle_resolve - address 2001:41b8:202:deb:213:21ff:fe20:1426
    handle_resolve - family PF_INET6
    handle_resolve - address 2001:858:2:2:aabb:0:563b:1e28
    handle_resolve - family PF_INET6
    connect_next - enter
    connect_next - PF_INET 154.35.132.70
    utils:ight_storage_init - enter
    utils:ight_storage_init - ok
    utils:ight_socket - enter
    utils:ight_socket - ok
    connect_next - ok
    Got response to TCP connect test
    Tearing down
    Written entry
    Increased
    Running next measurement
    Getting next line
    Returning new line
    Creating entry
    Calling setup
    Running with input ooni.nu
    utils:ight_timeval_init - enter
    utils:ight_timeval_init - ok
    dns - IPv4
    dns - adding '162.255.119.254'
    handle_resolve - enter
    handle_resolve - IPv4
    handle_resolve - address 162.255.119.254
    handle_resolve - family PF_INET
    dns - request failed: 70
    handle_resolve - enter
    connect_next - enter
    connect_next - PF_INET 162.255.119.254
    utils:ight_storage_init - enter
    utils:ight_storage_init - ok
    utils:ight_socket - enter
    utils:ight_socket - ok
    connect_next - ok
    Got response to TCP connect test
    Tearing down
    Written entry
    Increased
    Running next measurement
    Getting next line
    Returning new line
    Creating entry
    Calling setup
    Running with input neubot.org
    utils:ight_timeval_init - enter
    utils:ight_timeval_init - ok
    dns - IPv4
    dns - adding '130.192.16.172'
    handle_resolve - enter
    handle_resolve - IPv4
    handle_resolve - address 130.192.16.172
    handle_resolve - family PF_INET
    dns - request failed: 70
    handle_resolve - enter
    connect_next - enter
    connect_next - PF_INET 130.192.16.172
    utils:ight_storage_init - enter
    utils:ight_storage_init - ok
    utils:ight_socket - enter
    utils:ight_socket - ok
    connect_next - ok
    Got response to TCP connect test
    Tearing down
    Written entry
    Increased
    Running next measurement
    Getting next line
    EOF reached.
    Reached end of input
    ===============================================================================
    All tests passed (2 assertions in 3 test cases)

    ==31153==
    ==31153== HEAP SUMMARY:
    ==31153==     in use at exit: 0 bytes in 0 blocks
    ==31153==   total heap usage: 6,803 allocs, 6,803 frees, 493,762 bytes allocated
    ==31153==
    ==31153== All heap blocks were freed -- no leaks are possible
    ==31153==
    ==31153== For counts of detected and suppressed errors, rerun with: -v
    ==31153== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)