### PR TITLE
Make HTTP parser robust with respect to EOF

### DIFF
--- a/src/protocols/http.cpp
+++ b/src/protocols/http.cpp
@@ -272,12 +272,18 @@ public:
      *         a class derived from it) on several error conditions.
      */
     void eof() {
+        parsing = true;
         size_t n = http_parser_execute(&parser, &settings, NULL, 0);
+        parsing = false;
         if (parser.upgrade) {
             throw UpgradeError("Unexpected UPGRADE");
         }
         if (n != 0) {
             throw ParserError("Parser error");
+        }
+        if (closing) {
+            delete this;
+            return;
         }
     }
 


### PR DESCRIPTION
When HTTP parser receives EOF, `http_parser_execute()` is called. This function, in turn, may invoke callbacks that may destroy the parser.

Improve the code robustness by delaying destruction until the parser is ended.

Prevents accessing non allocated memory because after `http_parser_execute()` returns there is still code that is executed.