### PR TITLE
HTTP parser: prevent leak on parse error or upgrade

### DIFF
--- a/src/protocols/http.cpp
+++ b/src/protocols/http.cpp
@@ -140,10 +140,11 @@ class ResponseParserImpl {
 
     void parse(void) {
         auto total = (size_t) 0;
-        parsing = true;
         buffer.foreach([&](evbuffer_iovec *iov) {
+            parsing = true;
             size_t n = http_parser_execute(&parser, &settings,
                 (const char *) iov->iov_base, iov->iov_len);
+            parsing = false;
             if (parser.upgrade) {
                 throw UpgradeError("Unexpected UPGRADE");
             }
@@ -153,7 +154,6 @@ class ResponseParserImpl {
             total += iov->iov_len;
             return true;
         });
-        parsing = false;
         if (closing) {
             delete this;
             return;

--- a/test/protocols/http.cpp
+++ b/test/protocols/http.cpp
@@ -50,6 +50,31 @@ TEST_CASE("We don't leak when we receive an invalid message") {
     REQUIRE_THROWS(parser.feed(data));
 }
 
+TEST_CASE("We don't leak when we receive a UPGRADE") {
+
+    //ight_set_verbose(1);
+
+    http::ResponseParser parser;
+    std::string data;
+
+    //
+    // We pass the parser an invalid message that should trigger an
+    // exception. After the exception, the internal parser should be
+    // in a state by which, when the external parser is deleted,
+    // the internal parser is also deleted.
+    //
+
+    data = "";
+    data += "HTTP/1.1 200 Ok\r\n";
+    data += "Content-Type: text/plain\r\n";
+    data += "Connection: upgrade\r\n";
+    data += "Upgrade: websockets\r\n";
+    data += "Server: Antani/1.0.0.0\r\n";
+    data += "\r\n";
+
+    REQUIRE_THROWS(parser.feed(data));
+}
+
 TEST_CASE("The HTTP response parser works as expected") {
     auto data = std::string();
     auto parser = ight::protocols::http::ResponseParser();

--- a/test/protocols/http.cpp
+++ b/test/protocols/http.cpp
@@ -25,6 +25,31 @@ using namespace ight::common;
 // ResponseParser unit test
 //
 
+TEST_CASE("We don't leak when we receive an invalid message") {
+
+    //ight_set_verbose(1);
+
+    http::ResponseParser parser;
+    std::string data;
+
+    //
+    // We pass the parser an invalid message that should trigger an
+    // exception. After the exception, the internal parser should be
+    // in a state by which, when the external parser is deleted,
+    // the internal parser is also deleted.
+    //
+
+    data = "";
+    data += "XXX XXX XXX XXX\r\n";
+    data += "Content-Type: text/plain\r\n";
+    data += "Connection: close\r\n";
+    data += "Server: Antani/1.0.0.0\r\n";
+    data += "\r\n";
+    data += "1234567";
+
+    REQUIRE_THROWS(parser.feed(data));
+}
+
 TEST_CASE("The HTTP response parser works as expected") {
     auto data = std::string();
     auto parser = ight::protocols::http::ResponseParser();


### PR DESCRIPTION
Spotted by working on #80. Before this pull request, the internal parser object was leaked if an exception was thrown while parsing (either because a parse error or because the `upgrade` header was seen).