### PR TITLE
Make sure http::Request callback is called only once on EOF

### DIFF
--- a/src/net/connection.hpp
+++ b/src/net/connection.hpp
@@ -170,6 +170,22 @@ class ConnectionState {
 	}
 
 	void close(void);
+
+	void emit_connect() {
+		on_connect_fn();
+	}
+
+	void emit_data(SharedPointer<IghtBuffer> data) {
+		on_data_fn(data);
+	}
+
+	void emit_flush() {
+		on_flush_fn();
+	}
+
+	void emit_error(IghtError err) {
+		on_error_fn(err);
+	}
 };
 
 class Connection : public Transport {
@@ -177,6 +193,31 @@ class Connection : public Transport {
 	ConnectionState *state = NULL;
 
     public:
+
+	virtual void emit_connect() override {
+		if (state == NULL)
+			throw std::runtime_error("Invalid state");
+		state->emit_connect();
+	}
+
+	virtual void emit_data(SharedPointer<IghtBuffer> data) override {
+		if (state == NULL)
+			throw std::runtime_error("Invalid state");
+		state->emit_data(data);
+	}
+
+	virtual void emit_flush() override {
+		if (state == NULL)
+			throw std::runtime_error("Invalid state");
+		state->emit_flush();
+	}
+
+	virtual void emit_error(IghtError err) override {
+		if (state == NULL)
+			throw std::runtime_error("Invalid state");
+		state->emit_error(err);
+	}
+
 	Connection(void) {
 		/* nothing to do */
 	}

--- a/src/net/socks5.hpp
+++ b/src/net/socks5.hpp
@@ -40,6 +40,23 @@ protected:
     std::string proxy_port;
 
 public:
+
+    virtual void emit_connect() override {
+        conn->emit_connect();
+    }
+
+    virtual void emit_data(SharedPointer<IghtBuffer> data) override {
+        conn->emit_data(data);
+    }
+
+    virtual void emit_flush() override {
+        conn->emit_flush();
+    }
+
+    virtual void emit_error(IghtError err) override {
+        conn->emit_error(err);
+    }
+
     Socks5(Settings);
 
     virtual void on_connect(std::function<void()> fn) override {

--- a/src/net/transport.hpp
+++ b/src/net/transport.hpp
@@ -32,6 +32,14 @@ using namespace ight::common;
 
 struct Transport : public NonMovable, public NonCopyable {
 
+    virtual void emit_connect() = 0;
+
+    virtual void emit_data(SharedPointer<IghtBuffer>) = 0;
+
+    virtual void emit_flush() = 0;
+
+    virtual void emit_error(IghtError) = 0;
+
     Transport() {}
 
     virtual void on_connect(std::function<void()>) = 0;

--- a/src/protocols/http.cpp
+++ b/src/protocols/http.cpp
@@ -272,12 +272,18 @@ public:
      *         a class derived from it) on several error conditions.
      */
     void eof() {
+        parsing = true;
         size_t n = http_parser_execute(&parser, &settings, NULL, 0);
+        parsing = false;
         if (parser.upgrade) {
             throw UpgradeError("Unexpected UPGRADE");
         }
         if (n != 0) {
             throw ParserError("Parser error");
+        }
+        if (closing) {
+            delete this;
+            return;
         }
     }
 

--- a/src/protocols/http.hpp
+++ b/src/protocols/http.hpp
@@ -595,7 +595,12 @@ public:
         }
         stream = std::make_shared<Stream>(settings);
         stream->on_error([this](IghtError err) {
-            emit_end(err, std::move(response));
+            if (err.error != 0) {
+                emit_end(err, std::move(response));
+            } else {
+                // When EOF is received, on_end() is called, therefore we
+                // don't need to call emit_end() again here.
+            }
         });
         stream->on_connect([this](void) {
             // TODO: improve the way in which we serialize the request

--- a/src/protocols/http.hpp
+++ b/src/protocols/http.hpp
@@ -630,6 +630,10 @@ public:
         });
     }
 
+    SharedPointer<Stream> get_stream() {
+        return stream;
+    }
+
     void close() {
         stream->close();
     }

--- a/src/protocols/http.hpp
+++ b/src/protocols/http.hpp
@@ -267,6 +267,10 @@ public:
         return parser;
     }
 
+    SharedPointer<Transport> get_transport() {
+        return connection;
+    }
+
     /*!
      * \brief Deleted copy constructor.
      * The `this` of this class is bound to lambdas, so it must


### PR DESCRIPTION
Based on #81, this pull request is related to #80. Here we make sure that, when EOF is received, http::Request callback is called once rather than twice.