### PR TITLE
Make embedders job simple

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -18,11 +18,13 @@ VERSION_INFO = 4:0:0
 AM_CFLAGS = $(LIBIGHT_W_FLAGS) $(LIBIGHT_I_FLAGS)
 AM_CXXFLAGS = $(LIBIGHT_W_FLAGS) $(LIBIGHT_I_FLAGS)
 
-lib_LTLIBRARIES = libight.la
-libight_la_LDFLAGS = -version-info $(VERSION_INFO)
+lib_LTLIBRARIES =  # Empty
+libight_la_LDFLAGS = -version-info $(VERSION_INFO) -lyaml-cpp
 libight_la_SOURCES =  # Empty
 
 noinst_LTLIBRARIES =  # Empty
 
 include src/include.am
 include test/include.am
+
+lib_LTLIBRARIES += libight.la

--- a/configure.ac
+++ b/configure.ac
@@ -172,6 +172,7 @@ fi
 # Step 3: if needed, prepare to compile our own yaml-cpp
 if test "$ight_yamlcpp_path"x = "builtin"x; then
     CPPFLAGS="$CPPFLAGS -Isrc/ext/yaml-cpp/include"
+    LDFLAGS="$LDFLAGS -Lsrc/ext/"
 fi
 AM_CONDITIONAL([USE_BUILTIN_YAMLCPP],
     [test "$ight_yamlcpp_path"x = "builtin"x])

--- a/configure.ac
+++ b/configure.ac
@@ -52,8 +52,9 @@ if test "$ight_libevent_path"x != "builtin"x; then
 fi
 
 if test "$ight_libevent_path"x = "builtin"x; then
-    CPPFLAGS="$CPPFLAGS -Isrc/ext/libevent/include"
-    LDFLAGS="$LDFLAGS -Lsrc/ext/libevent -levent"
+    CPPFLAGS="$CPPFLAGS -I \$(top_srcdir)/src/ext/libevent/include"
+    CPPFLAGS="$CPPFLAGS -I \$(top_builddir)/src/ext/libevent/include"
+    LDFLAGS="$LDFLAGS -L\$(top_builddir)/src/ext/libevent -levent"
     AC_CONFIG_SUBDIRS([src/ext/libevent])
 fi
 
@@ -110,11 +111,20 @@ fi
 
 # Step 3: if needed, prepare to include our own libboost
 if test "$ight_boost_path"x = "builtin"x; then
-    for dirname in src/ext/boost/*; do
-        if test -d $dirname; then
-            CPPFLAGS="$CPPFLAGS -I ${dirname}/include"
-        fi
-    done
+    CPPFLAGS="$CPPFLAGS -I \$(top_srcdir)/src/ext/boost/assert/include"
+    CPPFLAGS="$CPPFLAGS -I \$(top_srcdir)/src/ext/boost/config/include"
+    CPPFLAGS="$CPPFLAGS -I \$(top_srcdir)/src/ext/boost/core/include"
+    CPPFLAGS="$CPPFLAGS -I \$(top_srcdir)/src/ext/boost/detail/include"
+    CPPFLAGS="$CPPFLAGS -I \$(top_srcdir)/src/ext/boost/iterator/include"
+    CPPFLAGS="$CPPFLAGS -I \$(top_srcdir)/src/ext/boost/mpl/include"
+    CPPFLAGS="$CPPFLAGS -I \$(top_srcdir)/src/ext/boost/predef/include"
+    CPPFLAGS="$CPPFLAGS -I \$(top_srcdir)/src/ext/boost/preprocessor/include"
+    CPPFLAGS="$CPPFLAGS -I \$(top_srcdir)/src/ext/boost/smart_ptr/include"
+    CPPFLAGS="$CPPFLAGS -I \$(top_srcdir)/src/ext/boost/static_assert/include"
+    CPPFLAGS="$CPPFLAGS -I \$(top_srcdir)/src/ext/boost/throw_exception/include"
+    CPPFLAGS="$CPPFLAGS -I \$(top_srcdir)/src/ext/boost/type_traits/include"
+    CPPFLAGS="$CPPFLAGS -I \$(top_srcdir)/src/ext/boost/typeof/include"
+    CPPFLAGS="$CPPFLAGS -I \$(top_srcdir)/src/ext/boost/utility/include"
 fi
 
 
@@ -171,8 +181,8 @@ fi
 
 # Step 3: if needed, prepare to compile our own yaml-cpp
 if test "$ight_yamlcpp_path"x = "builtin"x; then
-    CPPFLAGS="$CPPFLAGS -Isrc/ext/yaml-cpp/include"
-    LDFLAGS="$LDFLAGS -Lsrc/ext/"
+    CPPFLAGS="$CPPFLAGS -I \$(top_srcdir)/src/ext/yaml-cpp/include"
+    LDFLAGS="$LDFLAGS -L\$(top_builddir)/src/ext/"
 fi
 AM_CONDITIONAL([USE_BUILTIN_YAMLCPP],
     [test "$ight_yamlcpp_path"x = "builtin"x])

--- a/src/ext/include.am
+++ b/src/ext/include.am
@@ -52,4 +52,14 @@ if USE_BUILTIN_YAMLCPP
 	src/ext/yaml-cpp/src/null.cpp \
 	src/ext/yaml-cpp/src/nodebuilder.cpp \
 	src/ext/yaml-cpp/src/scantoken.cpp
+
+install-data-hook:
+	HBASE=$(top_srcdir)/src/ext/yaml-cpp/include && \
+	for HEADER in `find $$HBASE -type f`; do \
+	    REL_HEADER=`echo $$HEADER | sed "s|$$HBASE/||g"`; \
+	    HEADER_DIR=`dirname $$REL_HEADER`; \
+	    $(MKDIR_P) $(DESTDIR)$(includedir)/$$HEADER_DIR; \
+	    $(INSTALL_HEADER) $$HEADER $(DESTDIR)$(includedir)/$$REL_HEADER; \
+	done
+
 endif

--- a/src/ext/include.am
+++ b/src/ext/include.am
@@ -17,12 +17,12 @@ libight_la_LIBADD += src/ext/libext.la
 
 if USE_BUILTIN_YAMLCPP
 
-    noinst_LTLIBRARIES += src/ext/libyamlcpp.la
+    lib_LTLIBRARIES += src/ext/libyaml-cpp.la
 
     # Adapt CXXFLAGS to yaml-cpp:
-    src_ext_libyamlcpp_la_CXXFLAGS = $(AM_CXXFLAGS) -Wno-deprecated-declarations -Wno-missing-prototypes
+    src_ext_libyaml_cpp_la_CXXFLAGS = $(AM_CXXFLAGS) -Wno-deprecated-declarations -Wno-missing-prototypes
 
-    src_ext_libyamlcpp_la_SOURCES = \
+    src_ext_libyaml_cpp_la_SOURCES = \
 	src/ext/yaml-cpp/src/stream.cpp \
 	src/ext/yaml-cpp/src/emitter.cpp \
 	src/ext/yaml-cpp/src/emit.cpp \
@@ -52,6 +52,4 @@ if USE_BUILTIN_YAMLCPP
 	src/ext/yaml-cpp/src/null.cpp \
 	src/ext/yaml-cpp/src/nodebuilder.cpp \
 	src/ext/yaml-cpp/src/scantoken.cpp
-
-    libight_la_LIBADD += src/ext/libyamlcpp.la
 endif

--- a/src/ext/include.am
+++ b/src/ext/include.am
@@ -61,5 +61,18 @@ install-data-hook:
 	    $(MKDIR_P) $(DESTDIR)$(includedir)/$$HEADER_DIR; \
 	    $(INSTALL_HEADER) $$HEADER $(DESTDIR)$(includedir)/$$REL_HEADER; \
 	done
+	BOOST_BASE=$(top_srcdir)/src/ext/boost && \
+	for BOOST_MOD in `ls $$BOOST_BASE`; do \
+	    if [ -d $$BOOST_BASE/$$BOOST_MOD/include ]; then \
+	        HBASE=$$BOOST_BASE/$$BOOST_MOD/include; \
+	        for HEADER in `find $$HBASE -type f`; do \
+	            REL_HEADER=`echo $$HEADER | sed "s|$$HBASE/||g"`; \
+	            HEADER_DIR=`dirname $$REL_HEADER`; \
+	            $(MKDIR_P) $(DESTDIR)$(includedir)/$$HEADER_DIR; \
+	            $(INSTALL_HEADER) $$HEADER \
+	                $(DESTDIR)$(includedir)/$$REL_HEADER; \
+	        done; \
+	    fi; \
+	done
 
 endif

--- a/test/include.am
+++ b/test/include.am
@@ -7,6 +7,7 @@ check_PROGRAMS =  # Empty
 #
 test_echo_client_evbuf_SOURCES = test/echo_client_evbuf.cpp
 test_echo_client_evbuf_LDADD = libight.la
+test_echo_client_evbuf_LDFLAGS = -lyaml-cpp
 check_PROGRAMS += test/echo_client_evbuf
 
 #
@@ -15,6 +16,7 @@ check_PROGRAMS += test/echo_client_evbuf
 
 test_common_delayed_call_SOURCES = test/common/delayed_call.cpp
 test_common_delayed_call_LDADD = libight.la
+test_common_delayed_call_LDFLAGS = -lyaml-cpp
 check_PROGRAMS += test/common/delayed_call
 TESTS += test/common/delayed_call
 
@@ -25,75 +27,90 @@ TESTS += test/common/log
 
 test_common_evbuffer_SOURCES = test/common/evbuffer.cpp
 test_common_evbuffer_LDADD = libight.la
+test_common_evbuffer_LDFLAGS = -lyaml-cpp
 check_PROGRAMS += test/common/evbuffer
 TESTS += test/common/evbuffer
 
 test_common_bufferevent_SOURCES = test/common/bufferevent.cpp
 test_common_bufferevent_LDADD = libight.la
+test_common_bufferevent_LDFLAGS = -lyaml-cpp
 check_PROGRAMS += test/common/bufferevent
 TESTS += test/common/bufferevent
 
 test_common_poller_SOURCES = test/common/poller.cpp
 test_common_poller_LDADD = libight.la
+test_common_poller_LDFLAGS = -lyaml-cpp
 check_PROGRAMS += test/common/poller
 TESTS += test/common/poller
 
 test_common_pointer_SOURCES = test/common/pointer.cpp
 test_common_pointer_LDADD = libight.la
+test_common_pointer_LDFLAGS = -lyaml-cpp
 check_PROGRAMS += test/common/pointer
 TESTS += test/common/pointer
 
 test_common_socket_valid_SOURCES = test/common/socket_valid.cpp
 test_common_socket_valid_LDADD = libight.la
+test_common_socket_valid_LDFLAGS = -lyaml-cpp
 check_PROGRAMS += test/common/socket_valid
 TESTS += test/common/socket_valid
 
 test_net_buffer_SOURCES = test/net/buffer.cpp
 test_net_buffer_LDADD = libight.la
+test_net_buffer_LDFLAGS = -lyaml-cpp
 check_PROGRAMS += test/net/buffer
 TESTS += test/net/buffer
 
 test_net_connection_SOURCES = test/net/connection.cpp
 test_net_connection_LDADD = libight.la
+test_net_connection_LDFLAGS = -lyaml-cpp
 check_PROGRAMS += test/net/connection
 TESTS += test/net/connection
 
 test_report_file_SOURCES = test/report/file.cpp
 test_report_file_LDADD = libight.la
+test_report_file_LDFLAGS = -lyaml-cpp
 check_PROGRAMS += test/report/file
 TESTS += test/report/file
 
 test_ooni_dns_injection_SOURCES = test/ooni/dns_injection.cpp
 test_ooni_dns_injection_LDADD = libight.la
+test_ooni_dns_injection_LDFLAGS = -lyaml-cpp
 check_PROGRAMS += test/ooni/dns_injection
 TESTS += test/ooni/dns_injection
 
 test_ooni_http_invalid_request_line_SOURCES = test/ooni/http_invalid_request_line.cpp
 test_ooni_http_invalid_request_line_LDADD = libight.la
+test_ooni_http_invalid_request_line_LDFLAGS = -lyaml-cpp
 check_PROGRAMS += test/ooni/http_invalid_request_line
 TESTS += test/ooni/http_invalid_request_line
 
 test_ooni_tcp_test_SOURCES = test/ooni/tcp_test.cpp
 test_ooni_tcp_test_LDADD = libight.la
+test_ooni_tcp_test_LDFLAGS = -lyaml-cpp
 check_PROGRAMS += test/ooni/tcp_test
 TESTS += test/ooni/tcp_test
 
 test_ooni_tcp_connect_SOURCES = test/ooni/tcp_connect.cpp
 test_ooni_tcp_connect_LDADD = libight.la
+test_ooni_tcp_connect_LDFLAGS = -lyaml-cpp
 check_PROGRAMS += test/ooni/tcp_connect
 TESTS += test/ooni/tcp_connect
 
 test_ooni_net_test_SOURCES = test/ooni/net_test.cpp
 test_ooni_net_test_LDADD = libight.la
+test_ooni_net_test_LDFLAGS = -lyaml-cpp
 check_PROGRAMS += test/ooni/net_test
 TESTS += test/ooni/net_test
 
 test_protocols_dns_SOURCES = test/protocols/dns.cpp
 test_protocols_dns_LDADD = libight.la
+test_protocols_dns_LDFLAGS = -lyaml-cpp
 check_PROGRAMS += test/protocols/dns
 TESTS += test/protocols/dns
 
 test_protocols_http_SOURCES = test/protocols/http.cpp
 test_protocols_http_LDADD = libight.la
+test_protocols_http_LDFLAGS = -lyaml-cpp
 check_PROGRAMS += test/protocols/http
 TESTS += test/protocols/http


### PR DESCRIPTION
This pull request teaches the build system to install yaml-cpp and boost headers when libight uses the builtin yaml-cpp. It also modifies the build system to compile a shared yaml-cpp library rather than embedding such library into libight. This simplifies the job of people who wants to embed libight into an application. Assuming that no dependencies are installed, one can run `./configure; make; make install DESTDIR=/foo/bar` to install at `/foo/bar` the libraries and headers of libight and of all its dependencies. Then, one can just import `/foo/bar` from his/her build system.