### PR TITLE
Increase libight headers consistency

### DIFF
--- a/include/ight/common/check_connectivity.hpp
+++ b/include/ight/common/check_connectivity.hpp
@@ -4,7 +4,6 @@
  * Libight is free software. See AUTHORS and LICENSE for more
  * information on the copying conditions.
  */
-
 #ifndef IGHT_COMMON_CHECK_CONNECTIVITY_HPP
 # define IGHT_COMMON_CHECK_CONNECTIVITY_HPP
 
@@ -82,6 +81,5 @@ public:
     }
 };
 
-}  // namespace
-
-#endif  /* IGHT_COMMON_CHECK_CONNECTIVITY_HPP */
+}
+#endif

--- a/include/ight/common/check_connectivity.hpp
+++ b/include/ight/common/check_connectivity.hpp
@@ -18,6 +18,8 @@ struct event_base;
 struct evdns_base;
 
 namespace ight {
+namespace common {
+namespace check_connectivity {
 
 using namespace ight::common::constraints;
 
@@ -30,7 +32,7 @@ using namespace ight::common::constraints;
  *
  * To check whether the network is down, do:
  *
- *     if (ight::Network::is_down()) {
+ *     if (Network::is_down()) {
  *         return;
  *     }
  *
@@ -81,5 +83,5 @@ public:
     }
 };
 
-}
+}}}
 #endif

--- a/include/ight/common/constraints.hpp
+++ b/include/ight/common/constraints.hpp
@@ -4,9 +4,8 @@
  * Libight is free software. See AUTHORS and LICENSE for more
  * information on the copying conditions.
  */
-
-#ifndef LIBIGHT_COMMON_CONSTRAINTS_HPP
-# define LIBIGHT_COMMON_CONSTRAINTS_HPP
+#ifndef IGHT_COMMON_CONSTRAINTS_HPP
+# define IGHT_COMMON_CONSTRAINTS_HPP
 
 namespace ight {
 namespace common {
@@ -24,5 +23,5 @@ struct NonCopyable {
     NonCopyable() {}
 };
 
-}}}  // namespaces
-#endif  // LIBIGHT_COMMON_CONSTRAINTS_HPP
+}}}
+#endif

--- a/include/ight/common/emitter.hpp
+++ b/include/ight/common/emitter.hpp
@@ -4,9 +4,8 @@
  * Libight is free software. See AUTHORS and LICENSE for more
  * information on the copying conditions.
  */
-
-#ifndef LIBIGHT_COMMON_EMITTER_HPP
-# define LIBIGHT_COMMON_EMITTER_HPP
+#ifndef IGHT_COMMON_EMITTER_HPP
+# define IGHT_COMMON_EMITTER_HPP
 
 /*
  * \brief Templates to implement event emitters.
@@ -66,5 +65,5 @@ public:
     }
 };
 
-}}}  // namespaces
-#endif  // LIBIGHT_COMMON_EMITTER_HPP
+}}}
+#endif

--- a/include/ight/common/error.hpp
+++ b/include/ight/common/error.hpp
@@ -4,9 +4,8 @@
  * Libight is free software. See AUTHORS and LICENSE for more
  * information on the copying conditions.
  */
-
-#ifndef LIBIGHT_COMMON_ERROR_HPP
-# define LIBIGHT_COMMON_ERROR_HPP
+#ifndef IGHT_COMMON_ERROR_HPP
+# define IGHT_COMMON_ERROR_HPP
 
 namespace ight {
 namespace common {
@@ -20,5 +19,5 @@ struct Error {
 	};
 };
 
-}}}  // namespaces
-#endif  /* LIBIGHT_COMMON_ERROR_H */
+}}}
+#endif

--- a/include/ight/common/error.hpp
+++ b/include/ight/common/error.hpp
@@ -5,8 +5,8 @@
  * information on the copying conditions.
  */
 
-#ifndef LIBIGHT_COMMON_ERROR_H
-# define LIBIGHT_COMMON_ERROR_H
+#ifndef LIBIGHT_COMMON_ERROR_HPP
+# define LIBIGHT_COMMON_ERROR_HPP
 
 namespace ight {
 namespace common {

--- a/include/ight/common/libevent.hpp
+++ b/include/ight/common/libevent.hpp
@@ -4,13 +4,12 @@
  * Libight is free software. See AUTHORS and LICENSE for more
  * information on the copying conditions.
  */
+#ifndef IGHT_COMMON_LIBEVENT_HPP
+# define IGHT_COMMON_LIBEVENT_HPP
 
 //
 // Libevent abstraction layer.
 //
-
-#ifndef LIBIGHT_COMMON_LIBEVENT_HPP
-# define LIBIGHT_COMMON_LIBEVENT_HPP
 
 #include <event2/buffer.h>
 #include <event2/bufferevent.h>
@@ -218,5 +217,5 @@ class BuffereventSocket : public NonCopyable, public NonMovable {
 	}
 };
 
-}}}  // namespaces
-#endif  // LIBIGHT_COMMON_LIBEVENT_HPP
+}}}
+#endif

--- a/include/ight/common/libevent.hpp
+++ b/include/ight/common/libevent.hpp
@@ -9,8 +9,8 @@
 // Libevent abstraction layer.
 //
 
-#ifndef LIBIGHT_COMMON_LIBEVENT_H
-# define LIBIGHT_COMMON_LIBEVENT_H
+#ifndef LIBIGHT_COMMON_LIBEVENT_HPP
+# define LIBIGHT_COMMON_LIBEVENT_HPP
 
 #include <event2/buffer.h>
 #include <event2/bufferevent.h>
@@ -219,4 +219,4 @@ class BuffereventSocket : public NonCopyable, public NonMovable {
 };
 
 }}}  // namespaces
-#endif  // LIBIGHT_COMMON_LIBEVENT_H
+#endif  // LIBIGHT_COMMON_LIBEVENT_HPP

--- a/include/ight/common/log.hpp
+++ b/include/ight/common/log.hpp
@@ -4,9 +4,8 @@
  * Libight is free software. See AUTHORS and LICENSE for more
  * information on the copying conditions.
  */
-
-#ifndef LIBIGHT_COMMON_LOG_HPP
-# define LIBIGHT_COMMON_LOG_HPP
+#ifndef IGHT_COMMON_LOG_HPP
+# define IGHT_COMMON_LOG_HPP
 
 #include <functional>
 
@@ -23,4 +22,4 @@ void ight_set_verbose(int);
 
 void ight_set_logger(std::function<void(const char *)>);
 
-#endif  // LIBIGHT_COMMON_LOG_HPP
+#endif

--- a/include/ight/common/pointer.hpp
+++ b/include/ight/common/pointer.hpp
@@ -4,9 +4,8 @@
  * Libight is free software. See AUTHORS and LICENSE for more
  * information on the copying conditions.
  */
-
-#ifndef LIBIGHT_COMMON_POINTER_HPP
-# define LIBIGHT_COMMON_POINTER_HPP
+#ifndef IGHT_COMMON_POINTER_HPP
+# define IGHT_COMMON_POINTER_HPP
 
 #include <memory>
 #include <stdexcept>
@@ -70,5 +69,5 @@ public:
     }
 };
 
-}}}  // namespaces
-#endif  // LIBIGHT_COMMON_POINTER_HPP
+}}}
+#endif

--- a/include/ight/common/poller.h
+++ b/include/ight/common/poller.h
@@ -9,7 +9,7 @@
 # define LIBIGHT_POLLER_H
 
 #include <ight/common/constraints.hpp>
-#include <ight/common/libevent.h>
+#include <ight/common/libevent.hpp>
 
 #include <functional>
 

--- a/include/ight/common/poller.hpp
+++ b/include/ight/common/poller.hpp
@@ -5,8 +5,8 @@
  * information on the copying conditions.
  */
 
-#ifndef LIBIGHT_POLLER_H
-# define LIBIGHT_POLLER_H
+#ifndef LIBIGHT_POLLER_HPP
+# define LIBIGHT_POLLER_HPP
 
 #include <ight/common/constraints.hpp>
 #include <ight/common/libevent.hpp>
@@ -110,4 +110,4 @@ inline void ight_break_loop(void) {
 	ight::common::poller::GlobalPoller::get()->break_loop();
 }
 
-#endif  // LIBIGHT_POLLER_H
+#endif  // LIBIGHT_POLLER_HPP

--- a/include/ight/common/poller.hpp
+++ b/include/ight/common/poller.hpp
@@ -4,9 +4,8 @@
  * Libight is free software. See AUTHORS and LICENSE for more
  * information on the copying conditions.
  */
-
-#ifndef LIBIGHT_POLLER_HPP
-# define LIBIGHT_POLLER_HPP
+#ifndef IGHT_COMMON_POLLER_HPP
+# define IGHT_COMMON_POLLER_HPP
 
 #include <ight/common/constraints.hpp>
 #include <ight/common/libevent.hpp>
@@ -84,7 +83,7 @@ struct GlobalPoller {
 		return (&singleton);
 	}
 };
-}}}  // namespaces
+}}}
 
 /*
  * Syntactic sugar:
@@ -110,4 +109,4 @@ inline void ight_break_loop(void) {
 	ight::common::poller::GlobalPoller::get()->break_loop();
 }
 
-#endif  // LIBIGHT_POLLER_HPP
+#endif

--- a/include/ight/common/settings.hpp
+++ b/include/ight/common/settings.hpp
@@ -11,8 +11,9 @@
 
 namespace ight {
 namespace common {
+namespace settings {
 
 typedef std::map<std::string, std::string> Settings;
 
-}}
+}}}
 #endif

--- a/include/ight/common/settings.hpp
+++ b/include/ight/common/settings.hpp
@@ -4,9 +4,8 @@
  * Libight is free software. See AUTHORS and LICENSE for more
  * information on the copying conditions.
  */
-
-#ifndef LIBIGHT_COMMON_SETTINGS_HPP
-# define LIBIGHT_COMMON_SETTINGS_HPP
+#ifndef IGHT_COMMON_SETTINGS_HPP
+# define IGHT_COMMON_SETTINGS_HPP
 
 #include <map>
 
@@ -15,5 +14,5 @@ namespace common {
 
 typedef std::map<std::string, std::string> Settings;
 
-}}  // namespaces
-#endif  // LIBIGHT_COMMON_SETTINGS_HPP
+}}
+#endif

--- a/include/ight/common/string_vector.h
+++ b/include/ight/common/string_vector.h
@@ -9,7 +9,7 @@
 # define LIBIGHT_STRINGVECTOR_H
 
 #include <ight/common/constraints.hpp>
-#include <ight/common/poller.h>
+#include <ight/common/poller.hpp>
 
 /*-
  * StringVector

--- a/include/ight/common/string_vector.hpp
+++ b/include/ight/common/string_vector.hpp
@@ -5,8 +5,8 @@
  * information on the copying conditions.
  */
 
-#ifndef LIBIGHT_STRINGVECTOR_H
-# define LIBIGHT_STRINGVECTOR_H
+#ifndef LIBIGHT_STRINGVECTOR_HPP
+# define LIBIGHT_STRINGVECTOR_HPP
 
 #include <ight/common/constraints.hpp>
 #include <ight/common/poller.hpp>
@@ -39,4 +39,4 @@ struct StringVector : public NonCopyable, public NonMovable {
 };
 
 }}}  // namespaces
-#endif  /* LIBIGHT_STRINGVECTOR_H */
+#endif  /* LIBIGHT_STRINGVECTOR_HPP */

--- a/include/ight/common/string_vector.hpp
+++ b/include/ight/common/string_vector.hpp
@@ -4,8 +4,8 @@
  * Libight is free software. See AUTHORS and LICENSE for more
  * information on the copying conditions.
  */
-#ifndef IGHT_COMMON_STRINGVECTOR_HPP
-# define IGHT_COMMON_STRINGVECTOR_HPP
+#ifndef IGHT_COMMON_STRING_VECTOR_HPP
+# define IGHT_COMMON_STRING_VECTOR_HPP
 
 #include <ight/common/constraints.hpp>
 #include <ight/common/poller.hpp>

--- a/include/ight/common/string_vector.hpp
+++ b/include/ight/common/string_vector.hpp
@@ -4,9 +4,8 @@
  * Libight is free software. See AUTHORS and LICENSE for more
  * information on the copying conditions.
  */
-
-#ifndef LIBIGHT_STRINGVECTOR_HPP
-# define LIBIGHT_STRINGVECTOR_HPP
+#ifndef IGHT_COMMON_STRINGVECTOR_HPP
+# define IGHT_COMMON_STRINGVECTOR_HPP
 
 #include <ight/common/constraints.hpp>
 #include <ight/common/poller.hpp>
@@ -38,5 +37,5 @@ struct StringVector : public NonCopyable, public NonMovable {
 	~StringVector(void);
 };
 
-}}}  // namespaces
-#endif  /* LIBIGHT_STRINGVECTOR_HPP */
+}}}
+#endif

--- a/include/ight/common/utils.hpp
+++ b/include/ight/common/utils.hpp
@@ -136,8 +136,8 @@ int ight_socket_connect(evutil_socket_t, struct sockaddr_storage *,
 int ight_socket_listen(evutil_socket_t, struct sockaddr_storage *,
     socklen_t);
 
-std::string randomStr(size_t length);
+std::string ight_random_str(size_t length);
 
-std::string randomSTR(size_t length);
+std::string ight_random_str_uppercase(size_t length);
 
 #endif

--- a/include/ight/common/utils.hpp
+++ b/include/ight/common/utils.hpp
@@ -4,9 +4,8 @@
  * Libight is free software. See AUTHORS and LICENSE for more
  * information on the copying conditions.
  */
-
-#ifndef LIBIGHT_COMMON_UTILS_H
-# define LIBIGHT_COMMON_UTILS_H
+#ifndef IGHT_COMMON_UTILS_HPP
+# define IGHT_COMMON_UTILS_HPP
 
 struct sockaddr_storage;
 struct timeval;
@@ -141,4 +140,4 @@ std::string randomStr(size_t length);
 
 std::string randomSTR(size_t length);
 
-#endif  /* LIBIGHT_COMMON_UTILS_H */
+#endif

--- a/include/ight/net/buffer.hpp
+++ b/include/ight/net/buffer.hpp
@@ -4,9 +4,8 @@
  * Libight is free software. See AUTHORS and LICENSE for more
  * information on the copying conditions.
  */
-
-#ifndef LIBIGHT_NET_BUFFER_HPP
-# define LIBIGHT_NET_BUFFER_HPP
+#ifndef IGHT_NET_BUFFER_HPP
+# define IGHT_NET_BUFFER_HPP
 
 #include <ight/common/constraints.hpp>
 #include <ight/common/utils.hpp>
@@ -352,5 +351,5 @@ class Buffer : public NonCopyable, public NonMovable  {
 	}
 };
 
-}}}  // namespaces
-#endif  /* LIBIGHT_NET_BUFFER_HPP */
+}}}
+#endif

--- a/include/ight/net/connection.hpp
+++ b/include/ight/net/connection.hpp
@@ -12,7 +12,7 @@
 #include <ight/common/error.hpp>
 #include <ight/common/pointer.hpp>
 #include <ight/common/poller.hpp>
-#include <ight/common/string_vector.h>
+#include <ight/common/string_vector.hpp>
 #include <ight/common/utils.hpp>
 
 #include <ight/net/buffer.hpp>

--- a/include/ight/net/connection.hpp
+++ b/include/ight/net/connection.hpp
@@ -11,7 +11,7 @@
 #include <ight/common/constraints.hpp>
 #include <ight/common/error.hpp>
 #include <ight/common/pointer.hpp>
-#include <ight/common/poller.h>
+#include <ight/common/poller.hpp>
 #include <ight/common/string_vector.h>
 #include <ight/common/utils.hpp>
 

--- a/include/ight/net/connection.hpp
+++ b/include/ight/net/connection.hpp
@@ -9,7 +9,7 @@
 # define LIBIGHT_NET_CONNECTION_HPP
 
 #include <ight/common/constraints.hpp>
-#include <ight/common/error.h>
+#include <ight/common/error.hpp>
 #include <ight/common/pointer.hpp>
 #include <ight/common/poller.h>
 #include <ight/common/string_vector.h>

--- a/include/ight/net/connection.hpp
+++ b/include/ight/net/connection.hpp
@@ -4,9 +4,8 @@
  * Libight is free software. See AUTHORS and LICENSE for more
  * information on the copying conditions.
  */
-
-#ifndef LIBIGHT_NET_CONNECTION_HPP
-# define LIBIGHT_NET_CONNECTION_HPP
+#ifndef IGHT_NET_CONNECTION_HPP
+# define IGHT_NET_CONNECTION_HPP
 
 #include <ight/common/constraints.hpp>
 #include <ight/common/error.hpp>
@@ -341,5 +340,5 @@ class Connection : public Transport {
 	}
 };
 
-}}}  // namespaces
-#endif  /* LIBIGHT_NET_CONNECTION_HPP */
+}}}
+#endif

--- a/include/ight/net/socks5.hpp
+++ b/include/ight/net/socks5.hpp
@@ -4,9 +4,8 @@
  * Libight is free software. See AUTHORS and LICENSE for more
  * information on the copying conditions.
  */
-
-#ifndef LIBIGHT_NET_SOCKS5_HPP
-# define LIBIGHT_NET_SOCKS5_HPP
+#ifndef IGHT_NET_SOCKS5_HPP
+# define IGHT_NET_SOCKS5_HPP
 
 #include <ight/common/log.hpp>
 
@@ -122,4 +121,4 @@ public:
 };
 
 }}}
-#endif  // LIBIGHT_NET_SOCKS5_HPP
+#endif

--- a/include/ight/net/transport.hpp
+++ b/include/ight/net/transport.hpp
@@ -26,9 +26,9 @@ namespace net {
 namespace transport {
 
 using namespace ight::common::constraints;
-using namespace ight::common::pointer;
 using namespace ight::common::error;
-using namespace ight::common;
+using namespace ight::common::pointer;
+using namespace ight::common::settings;
 
 using namespace ight::net::buffer;
 

--- a/include/ight/net/transport.hpp
+++ b/include/ight/net/transport.hpp
@@ -16,7 +16,7 @@
 #include <string>
 
 #include <ight/common/constraints.hpp>
-#include <ight/common/error.h>
+#include <ight/common/error.hpp>
 #include <ight/common/pointer.hpp>
 #include <ight/common/settings.hpp>
 

--- a/include/ight/net/transport.hpp
+++ b/include/ight/net/transport.hpp
@@ -4,9 +4,8 @@
  * Libight is free software. See AUTHORS and LICENSE for more
  * information on the copying conditions.
  */
-
-#ifndef LIBIGHT_NET_TRANSPORT_HPP
-# define LIBIGHT_NET_TRANSPORT_HPP
+#ifndef IGHT_NET_TRANSPORT_HPP
+# define IGHT_NET_TRANSPORT_HPP
 
 //
 // Generic transport (stream socket, SOCKSv5, etc.)
@@ -76,6 +75,5 @@ struct Transport : public NonMovable, public NonCopyable {
 
 SharedPointer<Transport> connect(Settings);
 
-}}}  // namespace
-
-#endif  // LIBIGHT_NET_TRANSPORT_HPP
+}}}
+#endif

--- a/include/ight/ooni/dns_injection.hpp
+++ b/include/ight/ooni/dns_injection.hpp
@@ -12,11 +12,13 @@
 #include <ight/ooni/dns_test.hpp>
 #include <sys/stat.h>
 
-using namespace ight::ooni::dns_test;
-
 namespace ight {
 namespace ooni {
 namespace dns_injection {
+
+using namespace ight::common::settings;
+using namespace ight::ooni::dns_test;
+using namespace ight::report::entry;
 
 class InputFileDoesNotExist : public std::runtime_error {
   using std::runtime_error::runtime_error;
@@ -32,7 +34,7 @@ class DNSInjection : public DNSTest {
     std::function<void(ReportEntry)> have_entry;
 
 public:
-    DNSInjection(std::string input_filepath_, ight::common::Settings options_) : 
+    DNSInjection(std::string input_filepath_, Settings options_) : 
       DNSTest(input_filepath_, options_) {
         test_name = "dns_injection";
         test_version = "0.0.1";
@@ -47,7 +49,7 @@ public:
         }
     };
 
-    void main(std::string input, ight::common::Settings options,
+    void main(std::string input, Settings options,
               std::function<void(ReportEntry)>&& cb);
 };
 

--- a/include/ight/ooni/dns_injection.hpp
+++ b/include/ight/ooni/dns_injection.hpp
@@ -1,5 +1,11 @@
-#ifndef LIBIGHT_OONI_DNS_INJECTION_HPP
-# define LIBIGHT_OONI_DNS_INJECTION_HPP
+/*-
+ * This file is part of Libight <https://libight.github.io/>.
+ *
+ * Libight is free software. See AUTHORS and LICENSE for more
+ * information on the copying conditions.
+ */
+#ifndef IGHT_OONI_DNS_INJECTION_HPP
+# define IGHT_OONI_DNS_INJECTION_HPP
 
 #include <ight/protocols/dns.hpp>
 #include <ight/ooni/net_test.hpp>
@@ -46,5 +52,4 @@ public:
 };
 
 }}}
-
-#endif  // LIBIGHT_OONI_DNS_INJECTION_HPP
+#endif

--- a/include/ight/ooni/dns_test.hpp
+++ b/include/ight/ooni/dns_test.hpp
@@ -1,5 +1,11 @@
-#ifndef LIBIGHT_OONI_DNS_TEST_HPP
-# define LIBIGHT_OONI_DNS_TEST_HPP
+/*-
+ * This file is part of Libight <https://libight.github.io/>.
+ *
+ * Libight is free software. See AUTHORS and LICENSE for more
+ * information on the copying conditions.
+ */
+#ifndef IGHT_OONI_DNS_TEST_HPP
+# define IGHT_OONI_DNS_TEST_HPP
 
 #include <ight/common/pointer.hpp>
 
@@ -39,5 +45,4 @@ public:
 };
 
 }}}
-
 #endif

--- a/include/ight/ooni/dns_test.hpp
+++ b/include/ight/ooni/dns_test.hpp
@@ -16,6 +16,7 @@ namespace ight {
 namespace ooni {
 namespace dns_test {
 
+using namespace ight::common::settings;
 using namespace ight::common::pointer;
 
 struct UnsupportedQueryType : public std::runtime_error {
@@ -32,7 +33,7 @@ class DNSTest : public net_test::NetTest {
     SharedPointer<protocols::dns::Resolver> resolver;
 
 public:
-    DNSTest(std::string input_filepath_, ight::common::Settings options_) : 
+    DNSTest(std::string input_filepath_, Settings options_) : 
       net_test::NetTest(input_filepath_, options_) {
         test_name = "dns_test";
         test_version = "0.0.1";

--- a/include/ight/ooni/http_invalid_request_line.hpp
+++ b/include/ight/ooni/http_invalid_request_line.hpp
@@ -19,6 +19,9 @@ namespace ight {
 namespace ooni {
 namespace http_invalid_request_line {
 
+using namespace ight::common::settings;
+using namespace ight::report::entry;
+
 class InputFileDoesNotExist : public std::runtime_error {
   using std::runtime_error::runtime_error;
 };
@@ -31,13 +34,13 @@ class HTTPInvalidRequestLine: public HTTPTest {
     std::function<void(ReportEntry)> callback;
 
 public:
-    HTTPInvalidRequestLine(ight::common::Settings options_) : 
+    HTTPInvalidRequestLine(Settings options_) : 
       HTTPTest(options_) {
         test_name = "http_invalid_request_line";
         test_version = "0.0.1";
     };
     
-    void main(ight::common::Settings options,
+    void main(Settings options,
               std::function<void(ReportEntry)>&& cb);
 };
 

--- a/include/ight/ooni/http_invalid_request_line.hpp
+++ b/include/ight/ooni/http_invalid_request_line.hpp
@@ -1,5 +1,11 @@
-#ifndef LIBIGHT_OONI_HTTP_INVALID_REQUEST_LINE_HPP
-# define LIBIGHT_OONI_HTTP_INVALID_REQUEST_LINE_HPP
+/*-
+ * This file is part of Libight <https://libight.github.io/>.
+ *
+ * Libight is free software. See AUTHORS and LICENSE for more
+ * information on the copying conditions.
+ */
+#ifndef IGHT_OONI_HTTP_INVALID_REQUEST_LINE_HPP
+# define IGHT_OONI_HTTP_INVALID_REQUEST_LINE_HPP
 
 #include <ight/common/utils.hpp>
 #include <ight/protocols/http.hpp>
@@ -36,5 +42,4 @@ public:
 };
 
 }}}
-
-#endif  // LIBIGHT_OONI_HTTP_INVALID_REQUEST_LINE_HPP
+#endif

--- a/include/ight/ooni/http_test.hpp
+++ b/include/ight/ooni/http_test.hpp
@@ -16,6 +16,7 @@ namespace ooni {
 namespace http_test {
 
 using namespace ight::common::error;
+using namespace ight::common::settings;
 
 class HTTPTest : public net_test::NetTest {
     using net_test::NetTest::NetTest;
@@ -23,17 +24,17 @@ class HTTPTest : public net_test::NetTest {
     protocols::http::Client http_client;
 
 public:
-    HTTPTest(std::string input_filepath_, ight::common::Settings options_) : 
+    HTTPTest(std::string input_filepath_, Settings options_) : 
       net_test::NetTest(input_filepath_, options_) {
         test_name = "tcp_test";
         test_version = "0.0.1";
     };
 
-    HTTPTest(ight::common::Settings options_) : 
+    HTTPTest(Settings options_) : 
       HTTPTest("", options_)  {};
 
 
-    void request(ight::common::Settings settings, protocols::http::Headers headers,
+    void request(Settings settings, protocols::http::Headers headers,
                  std::string body,
                  protocols::http::RequestCallback&& callback) {
 

--- a/include/ight/ooni/http_test.hpp
+++ b/include/ight/ooni/http_test.hpp
@@ -1,5 +1,11 @@
-#ifndef LIBIGHT_OONI_HTTP_TEST_HPP
-# define LIBIGHT_OONI_HTTP_TEST_HPP
+/*-
+ * This file is part of Libight <https://libight.github.io/>.
+ *
+ * Libight is free software. See AUTHORS and LICENSE for more
+ * information on the copying conditions.
+ */
+#ifndef IGHT_OONI_HTTP_TEST_HPP
+# define IGHT_OONI_HTTP_TEST_HPP
 
 #include <ight/common/settings.hpp>
 #include <ight/protocols/http.hpp>
@@ -65,5 +71,4 @@ public:
 };
 
 }}}
-
 #endif

--- a/include/ight/ooni/net_test.hpp
+++ b/include/ight/ooni/net_test.hpp
@@ -1,5 +1,11 @@
-#ifndef LIBIGHT_OONI_NET_TEST_HPP
-# define LIBIGHT_OONI_NET_TEST_HPP
+/*-
+ * This file is part of Libight <https://libight.github.io/>.
+ *
+ * Libight is free software. See AUTHORS and LICENSE for more
+ * information on the copying conditions.
+ */
+#ifndef IGHT_OONI_NET_TEST_HPP
+# define IGHT_OONI_NET_TEST_HPP
 
 #include <iterator>
 #include <iostream>
@@ -139,5 +145,4 @@ public:
 };
 
 }}}
-
-#endif  // LIBIGHT_OONI_NET_TEST_HPP
+#endif

--- a/include/ight/ooni/net_test.hpp
+++ b/include/ight/ooni/net_test.hpp
@@ -25,6 +25,9 @@ namespace net_test {
 using namespace ight::common::libevent;
 using namespace ight::common::pointer;
 using namespace ight::common::poller;
+using namespace ight::common::settings;
+
+using namespace ight::report::file;
 
 class InputGenerator {
 
@@ -97,16 +100,16 @@ protected:
   virtual void teardown(std::string input);
   virtual void teardown();
 
-  virtual void main(ight::common::Settings options,
+  virtual void main(Settings options,
                     std::function<void(ReportEntry)>&& func);
 
 
-  virtual void main(std::string input, ight::common::Settings options,
+  virtual void main(std::string input, Settings options,
                     std::function<void(ReportEntry)>&& func);
 
 public:
   ReportEntry entry;
-  ight::common::Settings options;
+  Settings options;
   InputGenerator* input = nullptr;
 
   std::string test_name;
@@ -127,7 +130,7 @@ public:
 
   NetTest(std::string input_filepath);
 
-  NetTest(std::string input_filepath, ight::common::Settings options);
+  NetTest(std::string input_filepath, Settings options);
 
   InputGenerator* input_generator();
 

--- a/include/ight/ooni/net_test.hpp
+++ b/include/ight/ooni/net_test.hpp
@@ -8,7 +8,7 @@
 #include <ight/report/file.hpp>
 
 #include <ight/common/pointer.hpp>
-#include <ight/common/poller.h>
+#include <ight/common/poller.hpp>
 #include <ight/common/settings.hpp>
 #include <ight/common/log.hpp>
 

--- a/include/ight/ooni/tcp_connect.hpp
+++ b/include/ight/ooni/tcp_connect.hpp
@@ -10,11 +10,13 @@
 #include <ight/ooni/tcp_test.hpp>
 #include <sys/stat.h>
 
-using namespace ight::ooni::tcp_test;
-
 namespace ight {
 namespace ooni {
 namespace tcp_connect {
+
+using namespace ight::common::settings;
+using namespace ight::ooni::tcp_test;
+using namespace ight::report::entry;
 
 class InputFileDoesNotExist : public std::runtime_error {
   using std::runtime_error::runtime_error;
@@ -32,7 +34,7 @@ class TCPConnect : public TCPTest {
     std::function<void(ReportEntry)> have_entry;
 
 public:
-    TCPConnect(std::string input_filepath_, ight::common::Settings options_) : 
+    TCPConnect(std::string input_filepath_, Settings options_) : 
       TCPTest(input_filepath_, options_) {
         test_name = "tcp_connect";
         test_version = "0.0.1";
@@ -47,7 +49,7 @@ public:
         }
     };
 
-    void main(std::string input, ight::common::Settings options,
+    void main(std::string input, Settings options,
               std::function<void(ReportEntry)>&& cb);
 };
 

--- a/include/ight/ooni/tcp_connect.hpp
+++ b/include/ight/ooni/tcp_connect.hpp
@@ -1,5 +1,11 @@
-#ifndef LIBIGHT_OONI_TCP_CONNECT_HPP
-# define LIBIGHT_OONI_TCP_CONNECT_HPP
+/*-
+ * This file is part of Libight <https://libight.github.io/>.
+ *
+ * Libight is free software. See AUTHORS and LICENSE for more
+ * information on the copying conditions.
+ */
+#ifndef IGHT_OONI_TCP_CONNECT_HPP
+# define IGHT_OONI_TCP_CONNECT_HPP
 
 #include <ight/ooni/tcp_test.hpp>
 #include <sys/stat.h>
@@ -46,5 +52,4 @@ public:
 };
 
 }}}
-
-#endif  // LIBIGHT_OONI_TCP_CONNECT_HPP
+#endif

--- a/include/ight/ooni/tcp_test.hpp
+++ b/include/ight/ooni/tcp_test.hpp
@@ -1,5 +1,11 @@
-#ifndef LIBIGHT_OONI_TCP_TEST_HPP
-# define LIBIGHT_OONI_TCP_TEST_HPP
+/*-
+ * This file is part of Libight <https://libight.github.io/>.
+ *
+ * Libight is free software. See AUTHORS and LICENSE for more
+ * information on the copying conditions.
+ */
+#ifndef IGHT_OONI_TCP_TEST_HPP
+# define IGHT_OONI_TCP_TEST_HPP
 
 #include <ight/net/buffer.hpp>
 #include <ight/net/connection.hpp>
@@ -88,5 +94,4 @@ public:
 };
 
 }}}
-
 #endif

--- a/include/ight/ooni/tcp_test.hpp
+++ b/include/ight/ooni/tcp_test.hpp
@@ -22,6 +22,7 @@ namespace ooni {
 namespace tcp_test {
 
 using namespace ight::common::pointer;
+using namespace ight::common::settings;
 using namespace ight::net::connection;
 
 #if 0
@@ -83,13 +84,13 @@ class TCPTest : public net_test::NetTest {
     using net_test::NetTest::NetTest;
 
 public:
-    TCPTest(std::string input_filepath_, ight::common::Settings options_) : 
+    TCPTest(std::string input_filepath_, Settings options_) : 
       net_test::NetTest(input_filepath_, options_) {
         test_name = "tcp_test";
         test_version = "0.0.1";
     };
     
-    TCPClient connect(ight::common::Settings options,
+    TCPClient connect(Settings options,
             std::function<void()>&& cb);
 };
 

--- a/include/ight/protocols/dns.hpp
+++ b/include/ight/protocols/dns.hpp
@@ -31,6 +31,7 @@ using namespace ight::common::constraints;
 using namespace ight::common::libevent;
 using namespace ight::common::pointer;
 using namespace ight::common::poller;
+using namespace ight::common::settings;
 
 /*!
  * \brief DNS response.
@@ -270,7 +271,7 @@ class Resolver : public NonCopyable, public NonMovable {
     void cleanup(void);
 
 protected:
-    ight::common::Settings settings;
+    Settings settings;
     Libevent *libevent = GlobalLibevent::get();
     Poller *poller = ight_get_global_poller();
     evdns_base *base = NULL;
@@ -298,7 +299,7 @@ public:
      *        3 attempts, to timeout after 5.0 seconds, not to randomize
      *        the case.
      */
-    Resolver(ight::common::Settings settings_,
+    Resolver(Settings settings_,
             Libevent *lev = NULL, Poller *plr = NULL) {
         if (lev != NULL) {
             libevent = lev;

--- a/include/ight/protocols/dns.hpp
+++ b/include/ight/protocols/dns.hpp
@@ -4,9 +4,8 @@
  * Libight is free software. See AUTHORS and LICENSE for more
  * information on the copying conditions.
  */
-
-#ifndef LIBIGHT_PROTOCOLS_DNS_HPP
-# define LIBIGHT_PROTOCOLS_DNS_HPP
+#ifndef IGHT_PROTOCOLS_DNS_HPP
+# define IGHT_PROTOCOLS_DNS_HPP
 
 //
 // DNS client functionality
@@ -335,5 +334,5 @@ public:
     }
 };
 
-}}}  // namespace
-#endif  // LIBIGHT_PROTOCOLS_DNS_HPP
+}}}
+#endif

--- a/include/ight/protocols/dns.hpp
+++ b/include/ight/protocols/dns.hpp
@@ -15,7 +15,7 @@
 #include <ight/common/constraints.hpp>
 #include <ight/common/log.hpp>
 #include <ight/common/pointer.hpp>
-#include <ight/common/poller.h>
+#include <ight/common/poller.hpp>
 #include <ight/common/settings.hpp>
 
 #include <functional>

--- a/include/ight/protocols/http.hpp
+++ b/include/ight/protocols/http.hpp
@@ -17,7 +17,7 @@
 #include <ight/common/constraints.hpp>
 #include <ight/common/settings.hpp>
 #include <ight/common/log.hpp>
-#include <ight/common/error.h>
+#include <ight/common/error.hpp>
 #include <ight/common/pointer.hpp>
 
 #include <ight/net/buffer.hpp>

--- a/include/ight/protocols/http.hpp
+++ b/include/ight/protocols/http.hpp
@@ -4,9 +4,8 @@
  * Libight is free software. See AUTHORS and LICENSE for more
  * information on the copying conditions.
  */
-
-#ifndef LIBIGHT_PROTOCOLS_HTTP_HPP
-# define LIBIGHT_PROTOCOLS_HTTP_HPP
+#ifndef IGHT_PROTOCOLS_HTTP_HPP
+# define IGHT_PROTOCOLS_HTTP_HPP
 
 #include <functional>
 #include <map>
@@ -704,5 +703,5 @@ public:
     //
 };
 
-}}}  // namespaces
-#endif  // LIBIGHT_NET_HTTP_HPP
+}}}
+#endif

--- a/include/ight/protocols/http.hpp
+++ b/include/ight/protocols/http.hpp
@@ -36,6 +36,7 @@ namespace http {
 using namespace ight::common::constraints;
 using namespace ight::common::error;
 using namespace ight::common::pointer;
+using namespace ight::common::settings;
 
 using namespace ight::net;
 using namespace ight::net::buffer;
@@ -477,7 +478,7 @@ struct RequestSerializer {
      * \param headers HTTP headers (moved for efficiency).
      * \param body Request body (moved for efficiency).
      */
-    RequestSerializer(ight::common::Settings s, Headers headers,
+    RequestSerializer(Settings s, Headers headers,
                       std::string body);
 
     RequestSerializer() {
@@ -574,7 +575,7 @@ public:
      * \param callback Function invoked when request is complete.
      * \param parent Pointer to parent to implement self clean up.
      */
-    Request(const ight::common::Settings settings_, Headers headers,
+    Request(const Settings settings_, Headers headers,
             std::string body, RequestCallback&& callback_,
             std::set<Request *> *parent_ = nullptr)
                 : callback(callback_), parent(parent_) {
@@ -674,7 +675,7 @@ public:
      * \brief Issue HTTP request.
      * \see Request::Request.
      */
-    void request(ight::common::Settings settings, Headers headers,
+    void request(Settings settings, Headers headers,
             std::string body, RequestCallback&& callback) {
         auto r = new Request(settings, headers, body,
                 std::move(callback), &pending);

--- a/include/ight/report/base.hpp
+++ b/include/ight/report/base.hpp
@@ -1,5 +1,11 @@
-#ifndef LIBIGHT_REPORTER_BASE_HPP
-#define LIBIGHT_REPORTER_BASE_HPP
+/*-
+ * This file is part of Libight <https://libight.github.io/>.
+ *
+ * Libight is free software. See AUTHORS and LICENSE for more
+ * information on the copying conditions.
+ */
+#ifndef IGHT_REPORT_BASE_HPP
+#define IGHT_REPORT_BASE_HPP
 
 #include "yaml-cpp/yaml.h"
 #include <ight/report/entry.hpp>
@@ -37,4 +43,4 @@ public:
   virtual void close();
 };
 
-#endif /* BASE_HPP */
+#endif

--- a/include/ight/report/base.hpp
+++ b/include/ight/report/base.hpp
@@ -7,8 +7,14 @@
 #ifndef IGHT_REPORT_BASE_HPP
 #define IGHT_REPORT_BASE_HPP
 
-#include "yaml-cpp/yaml.h"
+#include <yaml-cpp/yaml.h>
 #include <ight/report/entry.hpp>
+
+namespace ight {
+namespace report {
+namespace base {
+
+using namespace ight::report::entry;
 
 class ReporterBase {
   bool closed = false;
@@ -43,4 +49,5 @@ public:
   virtual void close();
 };
 
+}}}
 #endif

--- a/include/ight/report/entry.hpp
+++ b/include/ight/report/entry.hpp
@@ -10,6 +10,10 @@
 #include <ctime>
 #include "yaml-cpp/yaml.h"
 
+namespace ight {
+namespace report {
+namespace entry {
+
 class ReportEntry {
 public:
   YAML::Node report;
@@ -42,4 +46,5 @@ public:
   ~ReportEntry() {};
 };
 
+}}}
 #endif

--- a/include/ight/report/entry.hpp
+++ b/include/ight/report/entry.hpp
@@ -1,5 +1,11 @@
-#ifndef LIBIGHT_REPORT_ENTRY_HPP
-#define LIBIGHT_REPORT_ENTRY_HPP
+/*-
+ * This file is part of Libight <https://libight.github.io/>.
+ *
+ * Libight is free software. See AUTHORS and LICENSE for more
+ * information on the copying conditions.
+ */
+#ifndef IGHT_REPORT_ENTRY_HPP
+#define IGHT_REPORT_ENTRY_HPP
 
 #include <ctime>
 #include "yaml-cpp/yaml.h"
@@ -36,4 +42,4 @@ public:
   ~ReportEntry() {};
 };
 
-#endif /* ENTRY_HPP */
+#endif

--- a/include/ight/report/file.hpp
+++ b/include/ight/report/file.hpp
@@ -12,6 +12,12 @@
 
 #include <ight/report/base.hpp>
 
+namespace ight {
+namespace report {
+namespace file {
+
+using namespace ight::report::base;
+
 class FileReporter : public ReporterBase {
   std::ofstream file;
 public:
@@ -21,4 +27,5 @@ public:
   void close();
 };
 
+}}}
 #endif

--- a/include/ight/report/file.hpp
+++ b/include/ight/report/file.hpp
@@ -1,5 +1,11 @@
-#ifndef LIBIGHT_FILE_REPORTER_HPP
-# define LIBIGHT_FILE_REPORTER_HPP
+/*-
+ * This file is part of Libight <https://libight.github.io/>.
+ *
+ * Libight is free software. See AUTHORS and LICENSE for more
+ * information on the copying conditions.
+ */
+#ifndef IGHT_REPORT_FILE_HPP
+# define IGHT_REPORT_FILE_HPP
 
 #include <iostream>
 #include <fstream>

--- a/src/common/check_connectivity.cpp
+++ b/src/common/check_connectivity.cpp
@@ -14,8 +14,10 @@
 #include <ight/common/check_connectivity.hpp>
 #include <ight/common/log.hpp>
 
+using namespace ight::common::check_connectivity;
+
 void
-ight::Network::cleanup(void)  // Idempotent cleanup function
+Network::cleanup(void)  // Idempotent cleanup function
 {
     if (dnsbase != NULL) {
         evdns_base_free(dnsbase, 0);
@@ -28,10 +30,10 @@ ight::Network::cleanup(void)  // Idempotent cleanup function
 }
 
 void
-ight::Network::dns_callback(int result, char type, int count, int ttl,
-                            void *addresses, void *opaque)
+Network::dns_callback(int result, char type, int count, int ttl,
+                      void *addresses, void *opaque)
 {
-    auto that = static_cast<ight::Network *>(opaque);
+    auto that = static_cast<Network *>(opaque);
 
     // Suppress "unused variable" warnings
     (void) type;
@@ -51,7 +53,7 @@ ight::Network::dns_callback(int result, char type, int count, int ttl,
     }
 }
 
-ight::Network::Network(void)
+Network::Network(void)
 {
     if ((evbase = event_base_new()) == NULL) {
         cleanup();

--- a/src/common/include.am
+++ b/src/common/include.am
@@ -18,7 +18,7 @@ commoninclude_HEADERS = \
     include/ight/common/settings.hpp \
     include/ight/common/utils.hpp \
     include/ight/common/error.hpp \
-    include/ight/common/libevent.h \
+    include/ight/common/libevent.hpp \
     include/ight/common/log.hpp \
     include/ight/common/poller.h \
     include/ight/common/string_vector.h

--- a/src/common/include.am
+++ b/src/common/include.am
@@ -20,5 +20,5 @@ commoninclude_HEADERS = \
     include/ight/common/error.hpp \
     include/ight/common/libevent.hpp \
     include/ight/common/log.hpp \
-    include/ight/common/poller.h \
+    include/ight/common/poller.hpp \
     include/ight/common/string_vector.h

--- a/src/common/include.am
+++ b/src/common/include.am
@@ -21,4 +21,4 @@ commoninclude_HEADERS = \
     include/ight/common/libevent.hpp \
     include/ight/common/log.hpp \
     include/ight/common/poller.hpp \
-    include/ight/common/string_vector.h
+    include/ight/common/string_vector.hpp

--- a/src/common/include.am
+++ b/src/common/include.am
@@ -17,7 +17,7 @@ commoninclude_HEADERS = \
     include/ight/common/pointer.hpp \
     include/ight/common/settings.hpp \
     include/ight/common/utils.hpp \
-    include/ight/common/error.h \
+    include/ight/common/error.hpp \
     include/ight/common/libevent.h \
     include/ight/common/log.hpp \
     include/ight/common/poller.h \

--- a/src/common/poller.cpp
+++ b/src/common/poller.cpp
@@ -13,7 +13,7 @@
 # include <signal.h>
 #endif
 
-#include <ight/common/poller.h>
+#include <ight/common/poller.hpp>
 #include <ight/common/utils.hpp>
 #include <ight/common/log.hpp>
 

--- a/src/common/string_vector.cpp
+++ b/src/common/string_vector.cpp
@@ -9,7 +9,7 @@
 #include <string.h>
 #include <stdlib.h>
 
-#include <ight/common/string_vector.h>
+#include <ight/common/string_vector.hpp>
 
 #define IGHT_STRINGVECTOR_MAX 512  // Large enough
 

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -242,7 +242,7 @@ ight_socket_listen(evutil_socket_t filedesc, struct sockaddr_storage *storage,
 
 // Stolen from:
 // http://stackoverflow.com/questions/440133/how-do-i-create-a-random-alpha-numeric-string-in-c
-std::string randomStr(size_t length)
+std::string ight_random_str(size_t length)
 {
     auto randchar = []() -> char
     {
@@ -258,7 +258,7 @@ std::string randomStr(size_t length)
     return str;
 }
 
-std::string randomSTR(size_t length)
+std::string ight_random_str_uppercase(size_t length)
 {
     auto randchar = []() -> char
     {

--- a/src/net/connection.cpp
+++ b/src/net/connection.cpp
@@ -13,7 +13,7 @@
 #include <event2/dns.h>
 
 #include <ight/common/log.hpp>
-#include <ight/common/string_vector.h>
+#include <ight/common/string_vector.hpp>
 #include <ight/net/connection.hpp>
 
 using namespace ight::common::error;

--- a/src/ooni/dns_injection.cpp
+++ b/src/ooni/dns_injection.cpp
@@ -1,10 +1,11 @@
 #include <ight/ooni/dns_injection.hpp>
 #include <sys/stat.h>
 
+using namespace ight::common::settings;
 using namespace ight::ooni::dns_injection;
 
 void
-DNSInjection::main(std::string input, ight::common::Settings options,
+DNSInjection::main(std::string input, Settings options,
                    std::function<void(ReportEntry)>&& cb)
 {
     entry["injected"] = NULL;

--- a/src/ooni/http_invalid_request_line.cpp
+++ b/src/ooni/http_invalid_request_line.cpp
@@ -1,10 +1,11 @@
 #include <ight/ooni/http_invalid_request_line.hpp>
 #include <sys/stat.h>
 
+using namespace ight::common::settings;
 using namespace ight::ooni::http_invalid_request_line;
 
 void
-HTTPInvalidRequestLine::main(ight::common::Settings options,
+HTTPInvalidRequestLine::main(Settings options,
                              std::function<void(ReportEntry)>&& cb)
 {
     

--- a/src/ooni/http_invalid_request_line.cpp
+++ b/src/ooni/http_invalid_request_line.cpp
@@ -27,7 +27,7 @@ HTTPInvalidRequestLine::main(Settings options,
     // randomSTR(4) + " / HTTP/1.1\n\r"
     request({
         {"url", options["backend"]},
-        {"method", randomSTR(4)},
+        {"method", ight_random_str_uppercase(4)},
         {"http_version", "HTTP/1.1"},
     }, headers, "", handle_response);
 
@@ -40,7 +40,7 @@ HTTPInvalidRequestLine::main(Settings options,
     // randomStr(1024) + ' / HTTP/1.1\n\r'
     request({
         {"url", options["backend"]},
-        {"method", randomSTR(1024)},
+        {"method", ight_random_str_uppercase(1024)},
         {"http_version", "HTTP/1.1"},
     }, headers, "", handle_response);
 
@@ -49,6 +49,6 @@ HTTPInvalidRequestLine::main(Settings options,
     request({
         {"url", options["backend"]},
         {"method", "GET"},
-        {"http_version", "HTTP/" + randomStr(3)},
+        {"http_version", "HTTP/" + ight_random_str(3)},
     }, headers, "", handle_response);
 }

--- a/src/ooni/net_test.cpp
+++ b/src/ooni/net_test.cpp
@@ -1,21 +1,22 @@
 #include <ight/ooni/net_test.hpp>
 #include <ctime>
 
+using namespace ight::common::settings;
 using namespace ight::ooni::net_test;
 
-NetTest::NetTest(std::string input_filepath_, ight::common::Settings options_)
+NetTest::NetTest(std::string input_filepath_, Settings options_)
   : input_filepath(input_filepath_), options(options_),
     test_name("net_test"), test_version("0.0.1")
 {
 }
 
-NetTest::NetTest(void) : NetTest::NetTest("", ight::common::Settings())
+NetTest::NetTest(void) : NetTest::NetTest("", Settings())
 {
   // nothing
 }
 
 NetTest::NetTest(std::string input_filepath_) : 
-  NetTest::NetTest(input_filepath_, ight::common::Settings())
+  NetTest::NetTest(input_filepath_, Settings())
 {
   // nothing
 }
@@ -143,7 +144,7 @@ NetTest::teardown() {
 }
 
 void
-NetTest::main(ight::common::Settings,
+NetTest::main(Settings,
               std::function<void(ReportEntry)>&& cb) {
   delayed_call = std::make_shared<DelayedCall>(1.25, [=](void) {
     ReportEntry entry;
@@ -152,7 +153,7 @@ NetTest::main(ight::common::Settings,
 }
 
 void
-NetTest::main(std::string, ight::common::Settings,
+NetTest::main(std::string, Settings,
               std::function<void(ReportEntry)>&& cb) {
   delayed_call = std::make_shared<DelayedCall>(1.25, [=](void) {
     ReportEntry entry;

--- a/src/ooni/tcp_connect.cpp
+++ b/src/ooni/tcp_connect.cpp
@@ -1,9 +1,10 @@
 #include <ight/ooni/tcp_connect.hpp>
 
+using namespace ight::common::settings;
 using namespace ight::ooni::tcp_connect;
 
 void
-TCPConnect::main(std::string input, ight::common::Settings options,
+TCPConnect::main(std::string input, Settings options,
                  std::function<void(ReportEntry)>&& cb)
 {
     options["host"] = input;

--- a/src/ooni/tcp_test.cpp
+++ b/src/ooni/tcp_test.cpp
@@ -2,10 +2,11 @@
 
 using namespace ight::common::error;
 using namespace ight::common::pointer;
+using namespace ight::common::settings;
 using namespace ight::ooni::tcp_test;
 
 TCPClient
-TCPTest::connect(ight::common::Settings options, std::function<void()>&& cb)
+TCPTest::connect(Settings options, std::function<void()>&& cb)
 {
     if (options["port"] == "") {
         throw std::runtime_error("Port is required");

--- a/src/protocols/http.cpp
+++ b/src/protocols/http.cpp
@@ -18,6 +18,7 @@
 
 #define MAXLINE 4096
 
+using namespace ight::common::settings;
 using namespace ight::net::buffer;
 using namespace ight::protocols::http;
 
@@ -383,7 +384,7 @@ ResponseParser::eof()
 // HTTP Request serializer
 //
 
-RequestSerializer::RequestSerializer(ight::common::Settings settings,
+RequestSerializer::RequestSerializer(Settings settings,
         Headers headers_, std::string body_)
                 : headers(headers_), body(body_)
 {

--- a/src/report/base.cpp
+++ b/src/report/base.cpp
@@ -1,5 +1,7 @@
 #include <ight/report/base.hpp>
 
+using namespace ight::report::base;
+
 std::string
 ReporterBase::getHeader() {
     std::stringstream output;

--- a/src/report/file.cpp
+++ b/src/report/file.cpp
@@ -1,5 +1,7 @@
 #include <ight/report/file.hpp>
 
+using namespace ight::report::file;
+
 void
 FileReporter::open() {
   ReporterBase::open();

--- a/test/common/bufferevent.cpp
+++ b/test/common/bufferevent.cpp
@@ -12,7 +12,7 @@
 #define CATCH_CONFIG_MAIN
 #include "src/ext/Catch/single_include/catch.hpp"
 
-#include <ight/common/poller.h>
+#include <ight/common/poller.hpp>
 
 using namespace ight::common::libevent;
 using namespace ight::common::poller;

--- a/test/common/delayed_call.cpp
+++ b/test/common/delayed_call.cpp
@@ -13,7 +13,7 @@
 #include "src/ext/Catch/single_include/catch.hpp"
 
 #include <ight/common/pointer.hpp>
-#include <ight/common/poller.h>
+#include <ight/common/poller.hpp>
 
 using namespace ight::common::libevent;
 using namespace ight::common::pointer;

--- a/test/common/evbuffer.cpp
+++ b/test/common/evbuffer.cpp
@@ -12,7 +12,7 @@
 #define CATCH_CONFIG_MAIN
 #include "src/ext/Catch/single_include/catch.hpp"
 
-#include <ight/common/libevent.h>
+#include <ight/common/libevent.hpp>
 
 using namespace ight::common::libevent;
 

--- a/test/common/poller.cpp
+++ b/test/common/poller.cpp
@@ -12,7 +12,7 @@
 #define CATCH_CONFIG_MAIN
 #include "src/ext/Catch/single_include/catch.hpp"
 
-#include <ight/common/poller.h>
+#include <ight/common/poller.hpp>
 
 #ifndef WIN32
 # include <sys/types.h>

--- a/test/net/buffer.cpp
+++ b/test/net/buffer.cpp
@@ -12,7 +12,7 @@
 #define CATCH_CONFIG_MAIN
 #include "src/ext/Catch/single_include/catch.hpp"
 
-#include <ight/common/libevent.h>
+#include <ight/common/libevent.hpp>
 #include <ight/net/buffer.hpp>
 
 using namespace ight::common::libevent;

--- a/test/net/connection.cpp
+++ b/test/net/connection.cpp
@@ -17,6 +17,7 @@
 
 #include <ight/net/connection.hpp>
 
+using namespace ight::common::check_connectivity;
 using namespace ight::common::poller;
 using namespace ight::net::connection;
 using namespace ight::net::buffer;
@@ -85,7 +86,7 @@ TEST_CASE("Ensure that the constructor socket-validity checks work") {
 }
 
 TEST_CASE("Connection::close() is idempotent") {
-    if (ight::Network::is_down()) {
+    if (Network::is_down()) {
         return;
     }
     Connection s("PF_INET", "nexa.polito.it", "80");
@@ -104,7 +105,7 @@ TEST_CASE("Connection::close() is idempotent") {
 }
 
 TEST_CASE("It is safe to manipulate Connection after close") {
-    if (ight::Network::is_down()) {
+    if (Network::is_down()) {
         return;
     }
     Connection s("PF_INET", "nexa.polito.it", "80");
@@ -124,7 +125,7 @@ TEST_CASE("It is safe to manipulate Connection after close") {
 }
 
 TEST_CASE("It is safe to close Connection while resolve is in progress") {
-    if (ight::Network::is_down()) {
+    if (Network::is_down()) {
         return;
     }
     ight_set_verbose(1);

--- a/test/ooni/dns_injection.cpp
+++ b/test/ooni/dns_injection.cpp
@@ -6,11 +6,12 @@
 #include <ight/common/log.hpp>
 #include <ight/common/utils.hpp>
 
+using namespace ight::common::settings;
 using namespace ight::ooni::dns_injection;
 
 TEST_CASE("The DNS Injection test should run with an input file of DNS hostnames") {
   ight_set_verbose(1);
-  ight::common::Settings options;
+  Settings options;
   options["nameserver"] = "8.8.8.8:53";
   DNSInjection dns_injection("test/fixtures/hosts.txt", options);
   dns_injection.begin([&](){
@@ -23,7 +24,7 @@ TEST_CASE("The DNS Injection test should run with an input file of DNS hostnames
 
 TEST_CASE("The DNS Injection test should throw an exception if an invalid file path is given") {
   ight_set_verbose(1);
-  ight::common::Settings options;
+  Settings options;
   options["nameserver"] = "8.8.8.8:53";
   REQUIRE_THROWS_AS(
       DNSInjection dns_injection("/tmp/this-file-does-not-exist.txt", options),
@@ -33,7 +34,7 @@ TEST_CASE("The DNS Injection test should throw an exception if an invalid file p
 
 TEST_CASE("The DNS Injection test should throw an exception if no file path is given") {
   ight_set_verbose(1);
-  ight::common::Settings options;
+  Settings options;
   options["nameserver"] = "8.8.8.8:53";
   REQUIRE_THROWS_AS(
       DNSInjection dns_injection("", options),

--- a/test/ooni/dns_injection.cpp
+++ b/test/ooni/dns_injection.cpp
@@ -2,7 +2,7 @@
 #include "src/ext/Catch/single_include/catch.hpp"
 
 #include <ight/ooni/dns_injection.hpp>
-#include <ight/common/poller.h>
+#include <ight/common/poller.hpp>
 #include <ight/common/log.hpp>
 #include <ight/common/utils.hpp>
 

--- a/test/ooni/http_invalid_request_line.cpp
+++ b/test/ooni/http_invalid_request_line.cpp
@@ -2,7 +2,7 @@
 #include "src/ext/Catch/single_include/catch.hpp"
 
 #include <ight/ooni/http_invalid_request_line.hpp>
-#include <ight/common/poller.h>
+#include <ight/common/poller.hpp>
 #include <ight/common/log.hpp>
 #include <ight/common/utils.hpp>
 

--- a/test/ooni/http_invalid_request_line.cpp
+++ b/test/ooni/http_invalid_request_line.cpp
@@ -6,11 +6,12 @@
 #include <ight/common/log.hpp>
 #include <ight/common/utils.hpp>
 
+using namespace ight::common::settings;
 using namespace ight::ooni::http_invalid_request_line;
 
 TEST_CASE("The HTTP Invalid Request Line test should run") {
   ight_set_verbose(1);
-  ight::common::Settings options;
+  Settings options;
   options["backend"] = "http://google.com/";
   HTTPInvalidRequestLine http_invalid_request_line(options);
   http_invalid_request_line.begin([&](){

--- a/test/ooni/net_test.cpp
+++ b/test/ooni/net_test.cpp
@@ -2,7 +2,7 @@
 #include "src/ext/Catch/single_include/catch.hpp"
 
 #include <ight/ooni/net_test.hpp>
-#include <ight/common/poller.h>
+#include <ight/common/poller.hpp>
 #include <ight/common/log.hpp>
 #include <ight/common/utils.hpp>
 

--- a/test/ooni/tcp_connect.cpp
+++ b/test/ooni/tcp_connect.cpp
@@ -6,6 +6,7 @@
 #include <ight/common/log.hpp>
 #include <ight/common/utils.hpp>
 
+using namespace ight::common::settings;
 using namespace ight::ooni::tcp_connect;
 
 TEST_CASE("The TCP connect test should run with an input file of DNS hostnames") {
@@ -23,7 +24,7 @@ TEST_CASE("The TCP connect test should run with an input file of DNS hostnames")
 
 TEST_CASE("The TCP connect test should throw an exception if an invalid file path is given") {
   REQUIRE_THROWS_AS(
-      TCPConnect("/tmp/this-file-does-not-exist.txt", ight::common::Settings()),
+      TCPConnect("/tmp/this-file-does-not-exist.txt", Settings()),
       InputFileDoesNotExist
   );
 }
@@ -31,7 +32,7 @@ TEST_CASE("The TCP connect test should throw an exception if an invalid file pat
 TEST_CASE("The TCP connect test should throw an exception if no file path is given") {
   ight_set_verbose(1);
   REQUIRE_THROWS_AS(
-      TCPConnect("", ight::common::Settings()),
+      TCPConnect("", Settings()),
       InputFileRequired
   );
 }

--- a/test/ooni/tcp_connect.cpp
+++ b/test/ooni/tcp_connect.cpp
@@ -2,7 +2,7 @@
 #include "src/ext/Catch/single_include/catch.hpp"
 
 #include <ight/ooni/tcp_connect.hpp>
-#include <ight/common/poller.h>
+#include <ight/common/poller.hpp>
 #include <ight/common/log.hpp>
 #include <ight/common/utils.hpp>
 

--- a/test/ooni/tcp_test.cpp
+++ b/test/ooni/tcp_test.cpp
@@ -3,7 +3,7 @@
 #include "src/ext/Catch/single_include/catch.hpp"
 
 #include <ight/ooni/tcp_test.hpp>
-#include <ight/common/poller.h>
+#include <ight/common/poller.hpp>
 #include <ight/common/log.hpp>
 #include <ight/common/utils.hpp>
 

--- a/test/ooni/tcp_test.cpp
+++ b/test/ooni/tcp_test.cpp
@@ -9,6 +9,7 @@
 
 #include <iostream>
 
+using namespace ight::common::settings;
 using namespace ight::ooni::tcp_test;
 
 TEST_CASE("TCPTest test should run")
@@ -53,7 +54,7 @@ TEST_CASE("TCPTest works as expected in a common case")
     ight_set_verbose(1);
 
     auto count = 0;
-    TCPTest tcp_test("", ight::common::Settings());
+    TCPTest tcp_test("", Settings());
 
     auto client1 = tcp_test.connect({
         {"host", "www.neubot.org"},

--- a/test/protocols/dns.cpp
+++ b/test/protocols/dns.cpp
@@ -18,8 +18,10 @@
 #include <ight/common/log.hpp>
 #include <ight/common/utils.hpp>
 
+using namespace ight::common::check_connectivity;
 using namespace ight::common::libevent;
 using namespace ight::common::poller;
+using namespace ight::common::settings;
 using namespace ight::protocols::dns;
 
 //
@@ -618,7 +620,7 @@ TEST_CASE("The system resolver works as expected") {
     // response fields from the system resolver.
     //
 
-    if (ight::Network::is_down()) {
+    if (Network::is_down()) {
         return;
     }
 
@@ -705,7 +707,7 @@ public:
 };
 
 TEST_CASE("It is safe to clear a request in its own callback") {
-    if (ight::Network::is_down()) {
+    if (Network::is_down()) {
         return;
     }
     auto d = SafeToDeleteRequestInItsOwnCallback();
@@ -735,7 +737,7 @@ TEST_CASE("Resolver: cleanup works correctly when we have allocated") {
 
     {
         // Note: call .get_evdns_base() to trigger lazy allocation
-        Resolver(ight::common::Settings(), &libevent)
+        Resolver(Settings(), &libevent)
             .get_evdns_base();
     }
 
@@ -773,7 +775,7 @@ TEST_CASE("Resolver: ensure that the constructor does not allocate") {
     //
 
     //Resolver();  // How to do this?
-    Resolver(ight::common::Settings(), &libevent);
+    Resolver(Settings(), &libevent);
 }
 
 TEST_CASE("Resolver: evdns_base_new failure is correctly handled") {
@@ -791,7 +793,7 @@ TEST_CASE("Resolver: evdns_base_new failure is correctly handled") {
     }, &libevent).get_evdns_base());
 
     // Handle the branch using the default nameserver
-    REQUIRE_THROWS(Resolver(ight::common::Settings(),
+    REQUIRE_THROWS(Resolver(Settings(),
         &libevent).get_evdns_base());
 }
 
@@ -940,7 +942,7 @@ TEST_CASE("We can override the default number of tries") {
 
 TEST_CASE("The default custom resolver works as expected") {
 
-    if (ight::Network::is_down()) {
+    if (Network::is_down()) {
         return;
     }
 
@@ -1014,7 +1016,7 @@ TEST_CASE("The default custom resolver works as expected") {
 
 TEST_CASE("A specific custom resolver works as expected") {
 
-    if (ight::Network::is_down()) {
+    if (Network::is_down()) {
         return;
     }
 
@@ -1025,7 +1027,7 @@ TEST_CASE("A specific custom resolver works as expected") {
         ight_break_loop();
     });
 
-    Resolver reso(ight::common::Settings({
+    Resolver reso(Settings({
         {"nameserver", "8.8.4.4"},
     }));
 
@@ -1095,7 +1097,7 @@ TEST_CASE("If the resolver dies the requests are aborted") {
     //
 
     // I need to remember to never run a DNS on that machine :^)
-    auto reso = new Resolver(ight::common::Settings({
+    auto reso = new Resolver(Settings({
         {"nameserver", "130.192.91.231"},
     }));
 
@@ -1136,7 +1138,7 @@ TEST_CASE("A request to a nonexistent server times out") {
     //
     // So, I'm commentin out this check:
     //
-    //if (ight::Network::is_down()) {
+    //if (Network::is_down()) {
     //    return;
     //}
     //
@@ -1169,7 +1171,7 @@ TEST_CASE("A request to a nonexistent server times out") {
 
 TEST_CASE("It is safe to cancel requests in flight") {
 
-    if (ight::Network::is_down()) {
+    if (Network::is_down()) {
         return;
     }
 

--- a/test/protocols/http.cpp
+++ b/test/protocols/http.cpp
@@ -13,7 +13,7 @@
 #include "src/ext/Catch/single_include/catch.hpp"
 
 #include <ight/common/check_connectivity.hpp>
-#include <ight/common/poller.h>
+#include <ight/common/poller.hpp>
 #include <ight/common/log.hpp>
 #include <ight/protocols/http.hpp>
 

--- a/test/protocols/http.cpp
+++ b/test/protocols/http.cpp
@@ -17,11 +17,12 @@
 #include <ight/common/log.hpp>
 #include <ight/protocols/http.hpp>
 
-using namespace ight::protocols;
-using namespace ight::net::buffer;
+using namespace ight::common::check_connectivity;
 using namespace ight::common::error;
 using namespace ight::common::pointer;
-using namespace ight::common;
+using namespace ight::common::settings;
+using namespace ight::net::buffer;
+using namespace ight::protocols;
 
 //
 // ResponseParser unit test
@@ -200,7 +201,7 @@ TEST_CASE("Response parser eof() does not trigger immediate distruction") {
 }
 
 TEST_CASE("HTTP stream works as expected") {
-    if (ight::Network::is_down()) {
+    if (Network::is_down()) {
         return;
     }
     //ight_set_verbose(1);
@@ -240,7 +241,7 @@ TEST_CASE("HTTP stream works as expected") {
 }
 
 TEST_CASE("HTTP stream works as expected when using Tor") {
-    if (ight::Network::is_down()) {
+    if (Network::is_down()) {
         return;
     }
     ight_set_verbose(1);
@@ -287,7 +288,7 @@ TEST_CASE("HTTP stream works as expected when using Tor") {
 }
 
 TEST_CASE("HTTP stream receives connection errors") {
-    if (ight::Network::is_down()) {
+    if (Network::is_down()) {
         return;
     }
     //ight_set_verbose(1);
@@ -584,7 +585,7 @@ TEST_CASE("Make sure that we can access OONI's bouncer using httpo://...") {
 TEST_CASE("Behavior is correct when only tor_socks_port is specified") {
     //ight_set_verbose(1);
 
-    ight::common::Settings settings{
+    Settings settings{
         {"method", "POST"},
         {"http_version", "HTTP/1.1"},
         {"tor_socks_port", "9055"},
@@ -613,7 +614,7 @@ TEST_CASE("Behavior is correct when only tor_socks_port is specified") {
 TEST_CASE("Behavior is correct with both tor_socks_port and socks5_proxy") {
     //ight_set_verbose(1);
 
-    ight::common::Settings settings{
+    Settings settings{
         {"method", "POST"},
         {"http_version", "HTTP/1.1"},
         {"tor_socks_port", "9999"},
@@ -643,7 +644,7 @@ TEST_CASE("Behavior is correct with both tor_socks_port and socks5_proxy") {
 TEST_CASE("Behavior is corrent when only socks5_proxy is specified") {
     //ight_set_verbose(1);
 
-    ight::common::Settings settings{
+    Settings settings{
         {"method", "POST"},
         {"http_version", "HTTP/1.1"},
         {"socks5_proxy", "127.0.0.1:9055"},
@@ -672,7 +673,7 @@ TEST_CASE("Behavior is corrent when only socks5_proxy is specified") {
 TEST_CASE("Behavior is OK w/o tor_socks_port and socks5_proxy") {
     //ight_set_verbose(1);
 
-    ight::common::Settings settings{
+    Settings settings{
         {"method", "POST"},
         {"http_version", "HTTP/1.1"},
     };
@@ -701,7 +702,7 @@ TEST_CASE("Make sure that settings are not modified") {
     ight_set_verbose(1);
     auto client = http::Client();
 
-    ight::common::Settings settings{
+    Settings settings{
         {"url", "httpo://nkvphnp3p6agi5qq.onion/bouncer"},
         {"method", "POST"},
         {"http_version", "HTTP/1.1"},

--- a/test/report/file.cpp
+++ b/test/report/file.cpp
@@ -5,6 +5,8 @@
 #include <ight/report/file.hpp>
 #include <ight/report/entry.hpp>
 
+using namespace ight::report::file;
+
 TEST_CASE("The constructor for [FileReport] works correctly", "[BaseReport]") {
   REQUIRE_NOTHROW(FileReporter());
 }


### PR DESCRIPTION
This pull request renames `foo.h` headers to `foo.hpp` and makes sure that namespaces are always used consistently, that all headers have a brief copyright statement, etc.

In a couple of cases, I've done this transformation: `void foo()` => `void ight_foo()`, which could possibly have been `void foo()` => `void ight::foo()` instead as discussed in #42. I plan to deal with applying the latter transformation with a subsequent pull request once we finish the discussion in #42.