### PR TITLE
Start tests asynchronously in a background thread (wrt master)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ stamp-h1
 .DS_Store
 
 # Regression tests
+test/common/async
 test/common/bufferevent
 test/common/delayed_call
 test/common/evbuffer

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
   - sudo apt-get install -qq gcc-4.8 g++-4.8
   - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
 install: autoreconf -i
-script: ./configure && make && make check
+script: ./configure && make && make check-am
 compiler:
   - clang
   - g++

--- a/configure.ac
+++ b/configure.ac
@@ -46,6 +46,12 @@ if test "$ight_libevent_path"x != "builtin"x; then
     AC_CHECK_LIB(event, event_new, [],
       [ight_libevent_path=builtin])
 
+    AC_CHECK_HEADERS(event2/thread.h, [],
+      [ight_libevent_path=builtin])
+
+    AC_CHECK_LIB(event_pthreads, evthread_use_pthreads, [],
+      [ight_libevent_path=builtin])
+
     if test "$ight_libevent_path"x = "builtin"x; then
        AC_MSG_WARN([No libevent found: will use the builtin libevent])
     fi
@@ -53,7 +59,7 @@ fi
 
 if test "$ight_libevent_path"x = "builtin"x; then
     CPPFLAGS="$CPPFLAGS -Isrc/ext/libevent/include"
-    LDFLAGS="$LDFLAGS -Lsrc/ext/libevent -levent"
+    LDFLAGS="$LDFLAGS -Lsrc/ext/libevent -levent -levent_pthreads"
     AC_CONFIG_SUBDIRS([src/ext/libevent])
 fi
 

--- a/include/ight/common/async.hpp
+++ b/include/ight/common/async.hpp
@@ -1,0 +1,48 @@
+/*-
+ * This file is part of Libight <https://libight.github.io/>.
+ *
+ * Libight is free software. See AUTHORS and LICENSE for more
+ * information on the copying conditions.
+ */
+#ifndef IGHT_COMMON_ASYNC_HPP
+# define IGHT_COMMON_ASYNC_HPP
+
+#include <ight/common/net_test.hpp>
+#include <ight/common/pointer.hpp>
+#include <ight/common/poller.h>
+
+namespace ight {
+namespace common {
+namespace async {
+
+using namespace ight::common::net_test;
+using namespace ight::common::pointer;
+using namespace ight::common::poller;
+
+struct AsyncState;
+
+class Async {
+    SharedPointer<AsyncState> state;
+
+    static void loop_thread(SharedPointer<AsyncState>);
+
+  public:
+
+    /// Default constructor
+    Async() : Async(SharedPointer<Poller>(new Poller())) {}
+
+    /// Constructor with specified poller
+    Async(SharedPointer<Poller> p);
+
+    /// Run the specified network test
+    void run_test(SharedPointer<NetTest> test);
+
+    /// Break out of the loop
+    void break_loop();
+
+    /// Restart the background loop
+    void restart_loop();
+};
+
+}}}
+#endif

--- a/include/ight/common/async.hpp
+++ b/include/ight/common/async.hpp
@@ -45,6 +45,18 @@ class Async {
 
     /// Returns true when no async jobs are running
     bool empty();
+
+    ///
+    /// Called when a test is completed
+    /// \warn This function is called from a background thread
+    ///
+    void on_complete(std::function<void(SharedPointer<NetTest>)>);
+
+    ///
+    /// Called when the tests queue is empty
+    /// \warn This function is called from a background thread
+    ///
+    void on_empty(std::function<void()>);
 };
 
 }}}

--- a/include/ight/common/async.hpp
+++ b/include/ight/common/async.hpp
@@ -42,6 +42,9 @@ class Async {
 
     /// Restart the background loop
     void restart_loop();
+
+    /// Returns true when no async jobs are running
+    bool empty();
 };
 
 }}}

--- a/include/ight/common/libevent.h
+++ b/include/ight/common/libevent.h
@@ -52,6 +52,9 @@ struct Libevent {
 	std::function<int(event_base*)> event_base_dispatch =
 	    ::event_base_dispatch;
 
+	std::function<int(event_base*, int)> event_base_loop =
+	    ::event_base_loop;
+
 	std::function<int(event_base*)> event_base_loopbreak =
 	    ::event_base_loopbreak;
 

--- a/include/ight/common/net_test.hpp
+++ b/include/ight/common/net_test.hpp
@@ -38,6 +38,17 @@ struct NetTest : public NonCopyable, public NonMovable {
      * \param func Callback called when the report is written.
      */
     virtual void end(std::function<void()> func) = 0;
+
+    /*!
+     * \brief Return the unique identifier of this test.
+     * \return Unique identifier of this test.
+     */
+    virtual unsigned long long identifier() {
+        return (unsigned long long) this;
+    }
+
+    /// Default destructor
+    virtual ~NetTest() {}
 };
 
 }}}

--- a/include/ight/common/net_test.hpp
+++ b/include/ight/common/net_test.hpp
@@ -1,0 +1,44 @@
+/*-
+ * This file is part of Libight <https://libight.github.io/>.
+ *
+ * Libight is free software. See AUTHORS and LICENSE for more
+ * information on the copying conditions.
+ */
+#ifndef IGHT_COMMON_NET_TEST_HPP
+# define IGHT_COMMON_NET_TEST_HPP
+
+///
+/// \file ight/common/net_test.hpp
+/// \brief Net class of all network tests.
+///
+
+#include <ight/common/constraints.hpp>
+#include <ight/common/settings.hpp>
+
+#include <functional>
+#include <string>
+
+namespace ight {
+namespace common {
+namespace net_test {
+
+using namespace ight::common::constraints;
+using namespace ight::common;
+
+struct NetTest : public NonCopyable, public NonMovable {
+
+    /*!
+     * \brief Start iterating over the input.
+     * \param func Callback called when we are done.
+     */
+    virtual void begin(std::function<void()> func) = 0;
+
+    /*!
+     * \brief Make sure that the report is written.
+     * \param func Callback called when the report is written.
+     */
+    virtual void end(std::function<void()> func) = 0;
+};
+
+}}}
+#endif

--- a/include/ight/common/pointer.hpp
+++ b/include/ight/common/pointer.hpp
@@ -50,7 +50,7 @@ public:
      *          the requested pointee field.
      * \throws std::runtime_error if the pointee is nullptr.
      */
-    T *operator->() {
+    T *operator->() const {
         if (this->get() == nullptr) {
             throw std::runtime_error("null pointer");
         }
@@ -62,7 +62,7 @@ public:
      * \returns The value of the pointee.
      * \throws std::runtime_error if the pointee is nullptr.
      */
-    typename std::add_lvalue_reference<T>::type operator*() {
+    typename std::add_lvalue_reference<T>::type operator*() const {
         if (this->get() == nullptr) {
             throw std::runtime_error("null pointer");
         }

--- a/include/ight/common/poller.h
+++ b/include/ight/common/poller.h
@@ -108,6 +108,10 @@ inline void ight_loop(void) {
 	ight::common::poller::GlobalPoller::get()->loop();
 }
 
+inline void ight_loop_once(void) {
+	ight::common::poller::GlobalPoller::get()->loop_once();
+}
+
 inline void ight_break_loop(void) {
 	ight::common::poller::GlobalPoller::get()->break_loop();
 }

--- a/include/ight/common/poller.h
+++ b/include/ight/common/poller.h
@@ -75,6 +75,8 @@ class Poller : public NonCopyable, public NonMovable {
 
 	void loop(void);
 
+	void loop_once(void);
+
 	void break_loop(void);
 };
 

--- a/include/ight/ooni/net_test.hpp
+++ b/include/ight/ooni/net_test.hpp
@@ -11,6 +11,7 @@
 #include <ight/common/poller.h>
 #include <ight/common/settings.hpp>
 #include <ight/common/log.hpp>
+#include <ight/common/net_test.hpp>
 
 namespace ight {
 namespace ooni {
@@ -68,7 +69,7 @@ private:
 
 };
 
-class NetTest {
+class NetTest : public ight::common::net_test::NetTest {
   std::string input_filepath;
   FileReporter file_report;
 
@@ -129,13 +130,13 @@ public:
    * \brief Start iterating over the input.
    * \param cb Callback called when we are done.
    */
-  void begin(std::function<void()>&& cb);
+  virtual void begin(std::function<void()> cb) override;
 
   /*!
    * \brief Make sure that the report is written.
    * \param cb Callback called when the report is written.
    */
-  void end(std::function<void()>&& cb);
+  virtual void end(std::function<void()> cb) override;
 };
 
 }}}

--- a/src/common/async.cpp
+++ b/src/common/async.cpp
@@ -118,8 +118,9 @@ void Async::break_loop() {
     state->interrupted = true;
 }
 
+// TODO: make sure this is enough to restart loop
 void Async::restart_loop() {
-    state->interrupted = true;
+    state->interrupted = false;
 }
 
 bool Async::empty() {

--- a/src/common/async.cpp
+++ b/src/common/async.cpp
@@ -47,11 +47,11 @@ void Async::loop_thread(SharedPointer<AsyncState> state) {
             ight_debug("loop thread locked");
             if (state->interrupted) {
                 ight_debug("interrupted");
-                return;
+                break;
             }
             if (state->ready.empty() && state->active.empty()) {
                 ight_debug("empty");
-                return;
+                break;
             }
             ight_debug("not interrupted and not empty");
             for (auto test : state->ready) {
@@ -112,4 +112,8 @@ void Async::break_loop() {
 
 void Async::restart_loop() {
     state->interrupted = true;
+}
+
+bool Async::empty() {
+    return !state->thread_running;
 }

--- a/src/common/async.cpp
+++ b/src/common/async.cpp
@@ -1,0 +1,97 @@
+/*-
+ * This file is part of Libight <https://libight.github.io/>.
+ *
+ * Libight is free software. See AUTHORS and LICENSE for more
+ * information on the copying conditions.
+ */
+
+#include <ight/common/async.hpp>
+
+#include <mutex>
+#include <set>
+#include <thread>
+
+using namespace ight::common::async;
+using namespace ight::common::pointer;
+
+namespace ight {
+namespace common {
+namespace async {
+
+// Shared state between foreground and background threads
+struct AsyncState {
+    std::set<SharedPointer<NetTest>> active;
+    volatile bool changed = false;
+    volatile bool interrupted = false;
+    std::mutex mutex;
+    SharedPointer<Poller> poller;
+    std::set<SharedPointer<NetTest>> ready;
+    std::thread thread;
+    volatile bool thread_running = false;
+};
+
+}}}
+
+// Syntactic sugar
+#define LOCKED(foo) do { \
+        std::lock_guard<std::mutex> lck(state->mutex); \
+        foo \
+    } while (0)
+
+void Async::loop_thread(SharedPointer<AsyncState> state) {
+    for (;;) {
+
+        LOCKED(
+            if (state->interrupted) {
+                break;
+            }
+            if (state->ready.empty() && state->active.empty()) {
+                break;
+            }
+            for (auto test : state->ready) {
+                state->active.insert(test);
+                test->begin([state, test]() {
+                    test->end([state, test]() {
+                        //
+                        // This callback is invoked by loop_once, when we do
+                        // not own the lock. For this reason it's important
+                        // to only modify state->active in the current thread
+                        //
+                        state->active.erase(test);
+                    });
+                });
+            }
+            state->ready.clear();
+        );
+
+        while (!state->changed) {
+            state->poller->loop_once();
+        }
+    }
+    state->thread_running = false;
+}
+
+Async::Async(SharedPointer<Poller> poller) {
+    state.reset(new AsyncState());
+    state->poller = poller;
+}
+
+void Async::run_test(SharedPointer<NetTest> test) {
+    LOCKED(
+        state->ready.insert(test);
+        state->changed = true;
+        if (!state->thread_running) {
+            state->thread = std::thread(loop_thread, state);
+            state->thread_running = true;
+        }
+    );
+}
+
+void Async::break_loop() {
+    state->poller->break_loop();  // Idempotent
+    state->interrupted = true;
+}
+
+void Async::restart_loop() {
+    state->interrupted = true;
+}

--- a/src/common/include.am
+++ b/src/common/include.am
@@ -1,6 +1,7 @@
 noinst_LTLIBRARIES += src/common/libcommon.la
 
 src_common_libcommon_la_SOURCES = \
+	src/common/async.cpp \
 	src/common/check_connectivity.cpp \
 	src/common/log.cpp \
 	src/common/poller.cpp \
@@ -11,6 +12,7 @@ libight_la_LIBADD += src/common/libcommon.la
 
 commonincludedir = $(includedir)/ight/common
 commoninclude_HEADERS = \
+    include/ight/common/async.hpp \
     include/ight/common/check_connectivity.hpp \
     include/ight/common/constraints.hpp \
     include/ight/common/emitter.hpp \

--- a/src/common/poller.cpp
+++ b/src/common/poller.cpp
@@ -157,6 +157,16 @@ Poller::loop(void)
 }
 
 void
+Poller::loop_once(void)
+{
+	auto result = this->libevent->event_base_loop(this->base, EVLOOP_ONCE);
+	if (result < 0)
+		throw std::runtime_error("event_base_loop() failed");
+	if (result == 1)
+		ight_warn("loop: no pending and/or active events");
+}
+
+void
 Poller::break_loop(void)
 {
 	if (this->libevent->event_base_loopbreak(this->base) != 0)

--- a/src/ooni/net_test.cpp
+++ b/src/ooni/net_test.cpp
@@ -78,7 +78,7 @@ NetTest::run_next_measurement(const std::function<void()>&& cb)
 }
 
 void
-NetTest::begin(std::function<void()>&& cb)
+NetTest::begin(std::function<void()> cb)
 {
   geoip_lookup();
   write_header();
@@ -120,7 +120,7 @@ NetTest::write_header()
 }
 
 void
-NetTest::end(std::function<void()>&& cb)
+NetTest::end(std::function<void()> cb)
 {
   file_report.close();
   cb();

--- a/test/common/async.cpp
+++ b/test/common/async.cpp
@@ -43,7 +43,8 @@ TEST_CASE("The async engine works as expected") {
         })
     ));
 
-    for (;;) {
+    // TODO Design a better sync mechanism
+    while (!async.empty()) {
         sleep(1);
     }
 }

--- a/test/common/async.cpp
+++ b/test/common/async.cpp
@@ -1,0 +1,49 @@
+/*-
+ * This file is part of Libight <https://libight.github.io/>.
+ *
+ * Libight is free software. See AUTHORS and LICENSE for more
+ * information on the copying conditions.
+ */
+
+//
+// Tests for src/common/async.cpp's
+//
+
+#define CATCH_CONFIG_MAIN
+#include "src/ext/Catch/single_include/catch.hpp"
+
+#include <ight/common/async.hpp>
+#include <ight/common/log.hpp>
+#include <ight/common/pointer.hpp>
+#include <ight/common/settings.hpp>
+
+#include <ight/ooni/http_invalid_request_line.hpp>
+
+#include <event2/thread.h>  // XXX
+#include <unistd.h>  // XXX
+
+using namespace ight::common::async;
+using namespace ight::common::pointer;
+using namespace ight::common;
+
+using namespace ight::ooni::http_invalid_request_line;
+
+TEST_CASE("The async engine works as expected") {
+    evthread_use_pthreads();
+    ight_set_verbose(1);
+    Async async;
+    async.run_test(SharedPointer<HTTPInvalidRequestLine>(
+        new HTTPInvalidRequestLine(Settings{
+            {"backend", "http://213.138.109.232/"},
+        })
+    ));
+    async.run_test(SharedPointer<HTTPInvalidRequestLine>(
+        new HTTPInvalidRequestLine(Settings{
+            {"backend", "http://www.google.com/"},
+        })
+    ));
+
+    for (;;) {
+        sleep(1);
+    }
+}

--- a/test/common/async.cpp
+++ b/test/common/async.cpp
@@ -34,7 +34,7 @@ TEST_CASE("The async engine works as expected") {
     Async async;
     async.run_test(SharedPointer<HTTPInvalidRequestLine>(
         new HTTPInvalidRequestLine(Settings{
-            {"backend", "http://213.138.109.232/"},
+            {"backend", "http://nexa.polito.it/"},
         })
     ));
     async.run_test(SharedPointer<HTTPInvalidRequestLine>(

--- a/test/include.am
+++ b/test/include.am
@@ -13,6 +13,11 @@ check_PROGRAMS += test/echo_client_evbuf
 # The following tests instead are managed by Catch
 #
 
+test_common_async_SOURCES = test/common/async.cpp
+test_common_async_LDADD = libight.la
+check_PROGRAMS += test/common/async
+TESTS += test/common/async
+
 test_common_delayed_call_SOURCES = test/common/delayed_call.cpp
 test_common_delayed_call_LDADD = libight.la
 check_PROGRAMS += test/common/delayed_call


### PR DESCRIPTION
This is same as #104 except that this pull request is based on master rather than on #103:

> Hi @hellais and @lorenzoPrimi,
>
> in this branch I tried to implement the feature that starts tests asynchronously in a background thread directly into libight, as suggested [in libight_ios pull request #2](https://github.com/TheTorProject/libight_iOS/pull/2).
>
> I'm not sure the code in here is good to be merged also because it contains some memory leaks, but I think it's a good starting point to discuss what I have tried to do.
>
> Note that for convenience I have also created [a branch pointing to this branch in the repository that I typically use to build libight on iOS](https://github.com/bassosimone/libight-build-ios/pull/2) so that you can rebuild a libight for iOS including the code in this pull request. Unfortunately, from there I cannot recompile libight for iOS because I need to install too much stuff on this MacOS and have a crappy Internet connection at the moment.
>
> What do you think of the code in here? (This pull request is based on #103 and [here's a useful link to only see what changed with respect to #103](https://github.com/TheTorProject/libight/compare/b03d0c5...618f2a4).)