### PR TITLE
Patches needed to move forward iOS application development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ stamp-h1
 .DS_Store
 
 # Regression tests
+test/common/async
 test/common/bufferevent
 test/common/delayed_call
 test/common/evbuffer

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
   - sudo apt-get install -qq gcc-4.8 g++-4.8
   - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
 install: autoreconf -i
-script: ./configure && make && make check
+script: ./configure && make && make check-am
 compiler:
   - clang
   - g++

--- a/Makefile.am
+++ b/Makefile.am
@@ -18,11 +18,13 @@ VERSION_INFO = 4:0:0
 AM_CFLAGS = $(LIBIGHT_W_FLAGS) $(LIBIGHT_I_FLAGS)
 AM_CXXFLAGS = $(LIBIGHT_W_FLAGS) $(LIBIGHT_I_FLAGS)
 
-lib_LTLIBRARIES = libight.la
-libight_la_LDFLAGS = -version-info $(VERSION_INFO)
+lib_LTLIBRARIES =  # Empty
+libight_la_LDFLAGS = -version-info $(VERSION_INFO) -lyaml-cpp
 libight_la_SOURCES =  # Empty
 
 noinst_LTLIBRARIES =  # Empty
 
 include src/include.am
 include test/include.am
+
+lib_LTLIBRARIES += libight.la

--- a/Makefile.am
+++ b/Makefile.am
@@ -15,11 +15,11 @@ LIBIGHT_I_FLAGS += -I $(top_srcdir)/src
 LIBIGHT_W_FLAGS = -Wall -Wmissing-prototypes -Wextra -pedantic
 
 VERSION_INFO = 4:0:0
-AM_CFLAGS = $(LIBIGHT_W_FLAGS) $(LIBIGHT_I_FLAGS)
-AM_CXXFLAGS = $(LIBIGHT_W_FLAGS) $(LIBIGHT_I_FLAGS)
+AM_CFLAGS = -pthread $(LIBIGHT_W_FLAGS) $(LIBIGHT_I_FLAGS)
+AM_CXXFLAGS = -pthread $(LIBIGHT_W_FLAGS) $(LIBIGHT_I_FLAGS)
 
 lib_LTLIBRARIES =  # Empty
-libight_la_LDFLAGS = -version-info $(VERSION_INFO) -lyaml-cpp
+libight_la_LDFLAGS = -pthread -version-info $(VERSION_INFO) -lyaml-cpp
 libight_la_SOURCES =  # Empty
 
 noinst_LTLIBRARIES =  # Empty

--- a/configure.ac
+++ b/configure.ac
@@ -172,6 +172,7 @@ fi
 # Step 3: if needed, prepare to compile our own yaml-cpp
 if test "$ight_yamlcpp_path"x = "builtin"x; then
     CPPFLAGS="$CPPFLAGS -Isrc/ext/yaml-cpp/include"
+    LDFLAGS="$LDFLAGS -Lsrc/ext/"
 fi
 AM_CONDITIONAL([USE_BUILTIN_YAMLCPP],
     [test "$ight_yamlcpp_path"x = "builtin"x])

--- a/configure.ac
+++ b/configure.ac
@@ -52,8 +52,9 @@ if test "$ight_libevent_path"x != "builtin"x; then
 fi
 
 if test "$ight_libevent_path"x = "builtin"x; then
-    CPPFLAGS="$CPPFLAGS -Isrc/ext/libevent/include"
-    LDFLAGS="$LDFLAGS -Lsrc/ext/libevent -levent"
+    CPPFLAGS="$CPPFLAGS -I \$(top_srcdir)/src/ext/libevent/include"
+    CPPFLAGS="$CPPFLAGS -I \$(top_builddir)/src/ext/libevent/include"
+    LDFLAGS="$LDFLAGS -L\$(top_builddir)/src/ext/libevent -levent"
     AC_CONFIG_SUBDIRS([src/ext/libevent])
 fi
 
@@ -110,11 +111,20 @@ fi
 
 # Step 3: if needed, prepare to include our own libboost
 if test "$ight_boost_path"x = "builtin"x; then
-    for dirname in src/ext/boost/*; do
-        if test -d $dirname; then
-            CPPFLAGS="$CPPFLAGS -I ${dirname}/include"
-        fi
-    done
+    CPPFLAGS="$CPPFLAGS -I \$(top_srcdir)/src/ext/boost/assert/include"
+    CPPFLAGS="$CPPFLAGS -I \$(top_srcdir)/src/ext/boost/config/include"
+    CPPFLAGS="$CPPFLAGS -I \$(top_srcdir)/src/ext/boost/core/include"
+    CPPFLAGS="$CPPFLAGS -I \$(top_srcdir)/src/ext/boost/detail/include"
+    CPPFLAGS="$CPPFLAGS -I \$(top_srcdir)/src/ext/boost/iterator/include"
+    CPPFLAGS="$CPPFLAGS -I \$(top_srcdir)/src/ext/boost/mpl/include"
+    CPPFLAGS="$CPPFLAGS -I \$(top_srcdir)/src/ext/boost/predef/include"
+    CPPFLAGS="$CPPFLAGS -I \$(top_srcdir)/src/ext/boost/preprocessor/include"
+    CPPFLAGS="$CPPFLAGS -I \$(top_srcdir)/src/ext/boost/smart_ptr/include"
+    CPPFLAGS="$CPPFLAGS -I \$(top_srcdir)/src/ext/boost/static_assert/include"
+    CPPFLAGS="$CPPFLAGS -I \$(top_srcdir)/src/ext/boost/throw_exception/include"
+    CPPFLAGS="$CPPFLAGS -I \$(top_srcdir)/src/ext/boost/type_traits/include"
+    CPPFLAGS="$CPPFLAGS -I \$(top_srcdir)/src/ext/boost/typeof/include"
+    CPPFLAGS="$CPPFLAGS -I \$(top_srcdir)/src/ext/boost/utility/include"
 fi
 
 
@@ -171,8 +181,8 @@ fi
 
 # Step 3: if needed, prepare to compile our own yaml-cpp
 if test "$ight_yamlcpp_path"x = "builtin"x; then
-    CPPFLAGS="$CPPFLAGS -Isrc/ext/yaml-cpp/include"
-    LDFLAGS="$LDFLAGS -Lsrc/ext/"
+    CPPFLAGS="$CPPFLAGS -I \$(top_srcdir)/src/ext/yaml-cpp/include"
+    LDFLAGS="$LDFLAGS -L\$(top_builddir)/src/ext/"
 fi
 AM_CONDITIONAL([USE_BUILTIN_YAMLCPP],
     [test "$ight_yamlcpp_path"x = "builtin"x])

--- a/configure.ac
+++ b/configure.ac
@@ -46,6 +46,12 @@ if test "$ight_libevent_path"x != "builtin"x; then
     AC_CHECK_LIB(event, event_new, [],
       [ight_libevent_path=builtin])
 
+    AC_CHECK_HEADERS(event2/thread.h, [],
+      [ight_libevent_path=builtin])
+
+    AC_CHECK_LIB(event_pthreads, evthread_use_pthreads, [],
+      [ight_libevent_path=builtin])
+
     if test "$ight_libevent_path"x = "builtin"x; then
        AC_MSG_WARN([No libevent found: will use the builtin libevent])
     fi
@@ -54,7 +60,7 @@ fi
 if test "$ight_libevent_path"x = "builtin"x; then
     CPPFLAGS="$CPPFLAGS -I \$(top_srcdir)/src/ext/libevent/include"
     CPPFLAGS="$CPPFLAGS -I \$(top_builddir)/src/ext/libevent/include"
-    LDFLAGS="$LDFLAGS -L\$(top_builddir)/src/ext/libevent -levent"
+    LDFLAGS="$LDFLAGS -L\$(top_builddir)/src/ext/libevent -levent -levent_pthreads"
     AC_CONFIG_SUBDIRS([src/ext/libevent])
 fi
 

--- a/include/ight/common/async.hpp
+++ b/include/ight/common/async.hpp
@@ -9,7 +9,7 @@
 
 #include <ight/common/net_test.hpp>
 #include <ight/common/pointer.hpp>
-#include <ight/common/poller.h>
+#include <ight/common/poller.hpp>
 
 namespace ight {
 namespace common {

--- a/include/ight/common/async.hpp
+++ b/include/ight/common/async.hpp
@@ -1,0 +1,48 @@
+/*-
+ * This file is part of Libight <https://libight.github.io/>.
+ *
+ * Libight is free software. See AUTHORS and LICENSE for more
+ * information on the copying conditions.
+ */
+#ifndef IGHT_COMMON_ASYNC_HPP
+# define IGHT_COMMON_ASYNC_HPP
+
+#include <ight/common/net_test.hpp>
+#include <ight/common/pointer.hpp>
+#include <ight/common/poller.h>
+
+namespace ight {
+namespace common {
+namespace async {
+
+using namespace ight::common::net_test;
+using namespace ight::common::pointer;
+using namespace ight::common::poller;
+
+struct AsyncState;
+
+class Async {
+    SharedPointer<AsyncState> state;
+
+    static void loop_thread(SharedPointer<AsyncState>);
+
+  public:
+
+    /// Default constructor
+    Async() : Async(SharedPointer<Poller>(new Poller())) {}
+
+    /// Constructor with specified poller
+    Async(SharedPointer<Poller> p);
+
+    /// Run the specified network test
+    void run_test(SharedPointer<NetTest> test);
+
+    /// Break out of the loop
+    void break_loop();
+
+    /// Restart the background loop
+    void restart_loop();
+};
+
+}}}
+#endif

--- a/include/ight/common/async.hpp
+++ b/include/ight/common/async.hpp
@@ -45,6 +45,18 @@ class Async {
 
     /// Returns true when no async jobs are running
     bool empty();
+
+    ///
+    /// Called when a test is completed
+    /// \warn This function is called from a background thread
+    ///
+    void on_complete(std::function<void(SharedPointer<NetTest>)>);
+
+    ///
+    /// Called when the tests queue is empty
+    /// \warn This function is called from a background thread
+    ///
+    void on_empty(std::function<void()>);
 };
 
 }}}

--- a/include/ight/common/async.hpp
+++ b/include/ight/common/async.hpp
@@ -9,7 +9,7 @@
 
 #include <ight/common/net_test.hpp>
 #include <ight/common/pointer.hpp>
-#include <ight/common/poller.hpp>
+#include <ight/common/poller.h>
 
 namespace ight {
 namespace common {

--- a/include/ight/common/async.hpp
+++ b/include/ight/common/async.hpp
@@ -42,6 +42,9 @@ class Async {
 
     /// Restart the background loop
     void restart_loop();
+
+    /// Returns true when no async jobs are running
+    bool empty();
 };
 
 }}}

--- a/include/ight/common/libevent.h
+++ b/include/ight/common/libevent.h
@@ -52,6 +52,8 @@ struct Libevent {
 	std::function<int(event_base*)> event_base_dispatch =
 	    ::event_base_dispatch;
 
+	std::function<int(event_base*)> event_base_loop = ::event_base_loop;
+
 	std::function<int(event_base*)> event_base_loopbreak =
 	    ::event_base_loopbreak;
 

--- a/include/ight/common/libevent.h
+++ b/include/ight/common/libevent.h
@@ -52,7 +52,8 @@ struct Libevent {
 	std::function<int(event_base*)> event_base_dispatch =
 	    ::event_base_dispatch;
 
-	std::function<int(event_base*)> event_base_loop = ::event_base_loop;
+	std::function<int(event_base*, int)> event_base_loop =
+            ::event_base_loop;
 
 	std::function<int(event_base*)> event_base_loopbreak =
 	    ::event_base_loopbreak;

--- a/include/ight/common/net_test.hpp
+++ b/include/ight/common/net_test.hpp
@@ -38,6 +38,17 @@ struct NetTest : public NonCopyable, public NonMovable {
      * \param func Callback called when the report is written.
      */
     virtual void end(std::function<void()> func) = 0;
+
+    /*!
+     * \brief Return the unique identifier of this test.
+     * \return Unique identifier of this test.
+     */
+    virtual unsigned long long identifier() {
+        return (unsigned long long) this;
+    }
+
+    /// Default destructor
+    virtual ~NetTest() {}
 };
 
 }}}

--- a/include/ight/common/net_test.hpp
+++ b/include/ight/common/net_test.hpp
@@ -1,0 +1,44 @@
+/*-
+ * This file is part of Libight <https://libight.github.io/>.
+ *
+ * Libight is free software. See AUTHORS and LICENSE for more
+ * information on the copying conditions.
+ */
+#ifndef IGHT_COMMON_NET_TEST_HPP
+# define IGHT_COMMON_NET_TEST_HPP
+
+///
+/// \file ight/common/net_test.hpp
+/// \brief Net class of all network tests.
+///
+
+#include <ight/common/constraints.hpp>
+#include <ight/common/settings.hpp>
+
+#include <functional>
+#include <string>
+
+namespace ight {
+namespace common {
+namespace net_test {
+
+using namespace ight::common::constraints;
+using namespace ight::common;
+
+struct NetTest : public NonCopyable, public NonMovable {
+
+    /*!
+     * \brief Start iterating over the input.
+     * \param func Callback called when we are done.
+     */
+    virtual void begin(std::function<void()> func) = 0;
+
+    /*!
+     * \brief Make sure that the report is written.
+     * \param func Callback called when the report is written.
+     */
+    virtual void end(std::function<void()> func) = 0;
+};
+
+}}}
+#endif

--- a/include/ight/common/pointer.hpp
+++ b/include/ight/common/pointer.hpp
@@ -50,7 +50,7 @@ public:
      *          the requested pointee field.
      * \throws std::runtime_error if the pointee is nullptr.
      */
-    T *operator->() {
+    T *operator->() const {
         if (this->get() == nullptr) {
             throw std::runtime_error("null pointer");
         }
@@ -62,7 +62,7 @@ public:
      * \returns The value of the pointee.
      * \throws std::runtime_error if the pointee is nullptr.
      */
-    typename std::add_lvalue_reference<T>::type operator*() {
+    typename std::add_lvalue_reference<T>::type operator*() const {
         if (this->get() == nullptr) {
             throw std::runtime_error("null pointer");
         }

--- a/include/ight/common/poller.h
+++ b/include/ight/common/poller.h
@@ -75,6 +75,8 @@ class Poller : public NonCopyable, public NonMovable {
 
 	void loop(void);
 
+	void loop_once(void);
+
 	void break_loop(void);
 };
 
@@ -104,6 +106,10 @@ inline evdns_base *ight_get_global_evdns_base(void) {
 
 inline void ight_loop(void) {
 	ight::common::poller::GlobalPoller::get()->loop();
+}
+
+inline void ight_loop_once(void) {
+    ight::common::poller::GlobalPoller::get()->loop_once();
 }
 
 inline void ight_break_loop(void) {

--- a/include/ight/net/dumb.hpp
+++ b/include/ight/net/dumb.hpp
@@ -1,0 +1,121 @@
+/*-
+ * This file is part of Libight <https://libight.github.io/>.
+ *
+ * Libight is free software. See AUTHORS and LICENSE for more
+ * information on the copying conditions.
+ */
+#ifndef IGHT_NET_DUMB_HPP
+# define IGHT_NET_DUMB_HPP
+
+//
+// Dumb transport
+//
+
+#include <ight/common/log.hpp>
+#include <ight/net/transport.hpp>
+
+namespace ight {
+namespace net {
+namespace dumb {
+
+using namespace ight::common::pointer;
+using namespace ight::common::error;
+using namespace ight::net::buffer;
+using namespace ight::net::transport;
+
+class Dumb : public Transport {
+
+    std::function<void()> do_connect;
+    std::function<void(SharedPointer<Buffer>)> do_data;
+    std::function<void()> do_flush;
+    std::function<void(Error)> do_error;
+
+public:
+
+    virtual void emit_connect() override {
+        ight_debug("dumb: emit 'connect' event");
+        do_connect();
+    }
+
+    virtual void emit_data(SharedPointer<Buffer> data) override {
+        ight_debug("dumb: emit 'data' event");
+        do_data(data);
+    }
+
+    virtual void emit_flush() override {
+        ight_debug("dumb: emit 'flush' event");
+        do_flush();
+    }
+
+    virtual void emit_error(Error err) override {
+        ight_debug("dumb: emit 'error' event");
+        do_error(err);
+    }
+
+    Dumb() {}
+
+    virtual void on_connect(std::function<void()> fn) override {
+        ight_debug("dumb: register 'connect' handler");
+        do_connect = fn;
+    }
+
+    virtual void on_ssl(std::function<void()>) override {
+        ight_debug("dumb: register 'ssl' handler");
+        // currently not implemented
+    }
+
+    virtual void
+    on_data(std::function<void(SharedPointer<Buffer>)> fn) override {
+        ight_debug("dumb: register 'data' handler");
+        do_data = fn;
+    }
+
+    virtual void on_flush(std::function<void()> fn) override {
+        ight_debug("dumb: register 'flush' handler");
+        do_flush = fn;
+    }
+
+    virtual void on_error(std::function<void(Error)> fn) override {
+        ight_debug("dumb: register 'error' handler");
+        do_error = fn;
+    }
+
+    virtual void set_timeout(double timeo) override {
+        ight_debug("dumb: set_timeout %f", timeo);
+    }
+
+    virtual void clear_timeout() override {
+        ight_debug("dumb: clear_timeout");
+    }
+
+    virtual void send(const void*, size_t) override {
+        ight_debug("dumb: send opaque data");
+    }
+
+    virtual void send(std::string) override {
+        ight_debug("dumb: send string");
+    }
+
+    virtual void send(SharedPointer<Buffer>) override {
+        ight_debug("dumb: send pointer to buffer");
+    }
+
+    virtual void send(Buffer&) override {
+        ight_debug("dumb: send buffer");
+    }
+
+    virtual void close() override {
+        ight_debug("dumb: close");
+    }
+
+    virtual std::string socks5_address() override {
+        return "";
+    }
+
+    virtual std::string socks5_port() override {
+        return "";
+    }
+};
+
+}}}
+#endif

--- a/include/ight/ooni/net_test.hpp
+++ b/include/ight/ooni/net_test.hpp
@@ -11,6 +11,7 @@
 #include <ight/common/poller.h>
 #include <ight/common/settings.hpp>
 #include <ight/common/log.hpp>
+#include <ight/common/net_test.hpp>
 
 namespace ight {
 namespace ooni {
@@ -68,7 +69,7 @@ private:
 
 };
 
-class NetTest {
+class NetTest : public ight::common::net_test::NetTest {
   std::string input_filepath;
   FileReporter file_report;
 
@@ -129,13 +130,13 @@ public:
    * \brief Start iterating over the input.
    * \param cb Callback called when we are done.
    */
-  void begin(std::function<void()>&& cb);
+  virtual void begin(std::function<void()> cb) override;
 
   /*!
    * \brief Make sure that the report is written.
    * \param cb Callback called when the report is written.
    */
-  void end(std::function<void()>&& cb);
+  virtual void end(std::function<void()> cb) override;
 };
 
 }}}

--- a/include/ight/protocols/http.hpp
+++ b/include/ight/protocols/http.hpp
@@ -249,11 +249,15 @@ class Stream {
         // TODO: convert error from integer to exception.
         //
         connection->on_error([&](Error error) {
+            auto safe_eh = error_handler;
             if (error.error == 0) {
                 parser->eof();
             }
-            if (error_handler) {
-                error_handler(error);
+            // parser->eof() may cause this object to go out of
+            // the scope, therefore we cannot trust `this` to be
+            // valid in the following code.
+            if (safe_eh) {
+                safe_eh(error);
             }
         });
         connect_handler();

--- a/src/common/async.cpp
+++ b/src/common/async.cpp
@@ -118,8 +118,9 @@ void Async::break_loop() {
     state->interrupted = true;
 }
 
+// TODO: make sure this is enough to restart loop
 void Async::restart_loop() {
-    state->interrupted = true;
+    state->interrupted = false;
 }
 
 bool Async::empty() {

--- a/src/common/async.cpp
+++ b/src/common/async.cpp
@@ -47,11 +47,11 @@ void Async::loop_thread(SharedPointer<AsyncState> state) {
             ight_debug("loop thread locked");
             if (state->interrupted) {
                 ight_debug("interrupted");
-                return;
+                break;
             }
             if (state->ready.empty() && state->active.empty()) {
                 ight_debug("empty");
-                return;
+                break;
             }
             ight_debug("not interrupted and not empty");
             for (auto test : state->ready) {
@@ -112,4 +112,8 @@ void Async::break_loop() {
 
 void Async::restart_loop() {
     state->interrupted = true;
+}
+
+bool Async::empty() {
+    return !state->thread_running;
 }

--- a/src/common/async.cpp
+++ b/src/common/async.cpp
@@ -1,0 +1,97 @@
+/*-
+ * This file is part of Libight <https://libight.github.io/>.
+ *
+ * Libight is free software. See AUTHORS and LICENSE for more
+ * information on the copying conditions.
+ */
+
+#include <ight/common/async.hpp>
+
+#include <mutex>
+#include <set>
+#include <thread>
+
+using namespace ight::common::async;
+using namespace ight::common::pointer;
+
+namespace ight {
+namespace common {
+namespace async {
+
+// Shared state between foreground and background threads
+struct AsyncState {
+    std::set<SharedPointer<NetTest>> active;
+    volatile bool changed = false;
+    volatile bool interrupted = false;
+    std::mutex mutex;
+    SharedPointer<Poller> poller;
+    std::set<SharedPointer<NetTest>> ready;
+    std::thread thread;
+    volatile bool thread_running = false;
+};
+
+}}}
+
+// Syntactic sugar
+#define LOCKED(foo) do { \
+        std::lock_guard<std::mutex> lck(state->mutex); \
+        foo \
+    } while (0)
+
+void Async::loop_thread(SharedPointer<AsyncState> state) {
+    for (;;) {
+
+        LOCKED(
+            if (state->interrupted) {
+                break;
+            }
+            if (state->ready.empty() && state->active.empty()) {
+                break;
+            }
+            for (auto test : state->ready) {
+                state->active.insert(test);
+                test->begin([state, test]() {
+                    test->end([state, test]() {
+                        //
+                        // This callback is invoked by loop_once, when we do
+                        // not own the lock. For this reason it's important
+                        // to only modify state->active in the current thread
+                        //
+                        state->active.erase(test);
+                    });
+                });
+            }
+            state->ready.clear();
+        );
+
+        while (!state->changed) {
+            state->poller->loop_once();
+        }
+    }
+    state->thread_running = false;
+}
+
+Async::Async(SharedPointer<Poller> poller) {
+    state.reset(new AsyncState());
+    state->poller = poller;
+}
+
+void Async::run_test(SharedPointer<NetTest> test) {
+    LOCKED(
+        state->ready.insert(test);
+        state->changed = true;
+        if (!state->thread_running) {
+            state->thread = std::thread(loop_thread, state);
+            state->thread_running = true;
+        }
+    );
+}
+
+void Async::break_loop() {
+    state->poller->break_loop();  // Idempotent
+    state->interrupted = true;
+}
+
+void Async::restart_loop() {
+    state->interrupted = true;
+}

--- a/src/common/include.am
+++ b/src/common/include.am
@@ -1,6 +1,7 @@
 noinst_LTLIBRARIES += src/common/libcommon.la
 
 src_common_libcommon_la_SOURCES = \
+	src/common/async.cpp \
 	src/common/check_connectivity.cpp \
 	src/common/log.cpp \
 	src/common/poller.cpp \
@@ -11,6 +12,7 @@ libight_la_LIBADD += src/common/libcommon.la
 
 commonincludedir = $(includedir)/ight/common
 commoninclude_HEADERS = \
+    include/ight/common/async.hpp \
     include/ight/common/check_connectivity.hpp \
     include/ight/common/constraints.hpp \
     include/ight/common/emitter.hpp \

--- a/src/common/poller.cpp
+++ b/src/common/poller.cpp
@@ -156,6 +156,14 @@ Poller::loop(void)
 		ight_warn("loop: no pending and/or active events");
 }
 
+void Poller::loop_once(void) {
+    auto result = this->libevent->event_base_loop(this->base, EVLOOP_ONCE);
+    if (result < 0)
+        throw std::runtime_error("event_base_loop() failed");
+    if (result == 1)
+        ight_warn("loop: no pending and/or active events");
+}
+
 void
 Poller::break_loop(void)
 {

--- a/src/ext/include.am
+++ b/src/ext/include.am
@@ -52,4 +52,14 @@ if USE_BUILTIN_YAMLCPP
 	src/ext/yaml-cpp/src/null.cpp \
 	src/ext/yaml-cpp/src/nodebuilder.cpp \
 	src/ext/yaml-cpp/src/scantoken.cpp
+
+install-data-hook:
+	HBASE=$(top_srcdir)/src/ext/yaml-cpp/include && \
+	for HEADER in `find $$HBASE -type f`; do \
+	    REL_HEADER=`echo $$HEADER | sed "s|$$HBASE/||g"`; \
+	    HEADER_DIR=`dirname $$REL_HEADER`; \
+	    $(MKDIR_P) $(DESTDIR)$(includedir)/$$HEADER_DIR; \
+	    $(INSTALL_HEADER) $$HEADER $(DESTDIR)$(includedir)/$$REL_HEADER; \
+	done
+
 endif

--- a/src/ext/include.am
+++ b/src/ext/include.am
@@ -17,12 +17,12 @@ libight_la_LIBADD += src/ext/libext.la
 
 if USE_BUILTIN_YAMLCPP
 
-    noinst_LTLIBRARIES += src/ext/libyamlcpp.la
+    lib_LTLIBRARIES += src/ext/libyaml-cpp.la
 
     # Adapt CXXFLAGS to yaml-cpp:
-    src_ext_libyamlcpp_la_CXXFLAGS = $(AM_CXXFLAGS) -Wno-deprecated-declarations -Wno-missing-prototypes
+    src_ext_libyaml_cpp_la_CXXFLAGS = $(AM_CXXFLAGS) -Wno-deprecated-declarations -Wno-missing-prototypes
 
-    src_ext_libyamlcpp_la_SOURCES = \
+    src_ext_libyaml_cpp_la_SOURCES = \
 	src/ext/yaml-cpp/src/stream.cpp \
 	src/ext/yaml-cpp/src/emitter.cpp \
 	src/ext/yaml-cpp/src/emit.cpp \
@@ -52,6 +52,4 @@ if USE_BUILTIN_YAMLCPP
 	src/ext/yaml-cpp/src/null.cpp \
 	src/ext/yaml-cpp/src/nodebuilder.cpp \
 	src/ext/yaml-cpp/src/scantoken.cpp
-
-    libight_la_LIBADD += src/ext/libyamlcpp.la
 endif

--- a/src/ext/include.am
+++ b/src/ext/include.am
@@ -61,5 +61,18 @@ install-data-hook:
 	    $(MKDIR_P) $(DESTDIR)$(includedir)/$$HEADER_DIR; \
 	    $(INSTALL_HEADER) $$HEADER $(DESTDIR)$(includedir)/$$REL_HEADER; \
 	done
+	BOOST_BASE=$(top_srcdir)/src/ext/boost && \
+	for BOOST_MOD in `ls $$BOOST_BASE`; do \
+	    if [ -d $$BOOST_BASE/$$BOOST_MOD/include ]; then \
+	        HBASE=$$BOOST_BASE/$$BOOST_MOD/include; \
+	        for HEADER in `find $$HBASE -type f`; do \
+	            REL_HEADER=`echo $$HEADER | sed "s|$$HBASE/||g"`; \
+	            HEADER_DIR=`dirname $$REL_HEADER`; \
+	            $(MKDIR_P) $(DESTDIR)$(includedir)/$$HEADER_DIR; \
+	            $(INSTALL_HEADER) $$HEADER \
+	                $(DESTDIR)$(includedir)/$$REL_HEADER; \
+	        done; \
+	    fi; \
+	done
 
 endif

--- a/src/net/include.am
+++ b/src/net/include.am
@@ -12,5 +12,6 @@ netincludedir = $(includedir)/ight/net
 netinclude_HEADERS = \
     include/ight/net/buffer.hpp \
     include/ight/net/connection.hpp \
+    include/ight/net/dumb.hpp \
     include/ight/net/socks5.hpp \
     include/ight/net/transport.hpp

--- a/src/net/transport.cpp
+++ b/src/net/transport.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <ight/net/connection.hpp>
+#include <ight/net/dumb.hpp>
 #include <ight/net/socks5.hpp>
 #include <ight/net/transport.hpp>
 
@@ -17,9 +18,14 @@ using namespace ight::common;
 using namespace ight::common::pointer;
 
 using namespace ight::net::connection;
+using namespace ight::net::dumb;
 using namespace ight::net::socks5;
 
 SharedPointer<Transport> connect(Settings settings) {
+
+    if (settings.find("dumb_transport") != settings.end()) {
+        return std::make_shared<Dumb>();
+    }
 
     if (settings.find("family") == settings.end()) {
         settings["family"] = "PF_UNSPEC";

--- a/src/ooni/net_test.cpp
+++ b/src/ooni/net_test.cpp
@@ -78,7 +78,7 @@ NetTest::run_next_measurement(const std::function<void()>&& cb)
 }
 
 void
-NetTest::begin(std::function<void()>&& cb)
+NetTest::begin(std::function<void()> cb)
 {
   geoip_lookup();
   write_header();
@@ -120,7 +120,7 @@ NetTest::write_header()
 }
 
 void
-NetTest::end(std::function<void()>&& cb)
+NetTest::end(std::function<void()> cb)
 {
   file_report.close();
   cb();

--- a/test/common/async.cpp
+++ b/test/common/async.cpp
@@ -43,7 +43,8 @@ TEST_CASE("The async engine works as expected") {
         })
     ));
 
-    for (;;) {
+    // TODO Design a better sync mechanism
+    while (!async.empty()) {
         sleep(1);
     }
 }

--- a/test/common/async.cpp
+++ b/test/common/async.cpp
@@ -24,7 +24,7 @@
 
 using namespace ight::common::async;
 using namespace ight::common::pointer;
-using namespace ight::common::settings;
+using namespace ight::common;
 
 using namespace ight::ooni::http_invalid_request_line;
 

--- a/test/common/async.cpp
+++ b/test/common/async.cpp
@@ -1,0 +1,49 @@
+/*-
+ * This file is part of Libight <https://libight.github.io/>.
+ *
+ * Libight is free software. See AUTHORS and LICENSE for more
+ * information on the copying conditions.
+ */
+
+//
+// Tests for src/common/async.cpp's
+//
+
+#define CATCH_CONFIG_MAIN
+#include "src/ext/Catch/single_include/catch.hpp"
+
+#include <ight/common/async.hpp>
+#include <ight/common/log.hpp>
+#include <ight/common/pointer.hpp>
+#include <ight/common/settings.hpp>
+
+#include <ight/ooni/http_invalid_request_line.hpp>
+
+#include <event2/thread.h>  // XXX
+#include <unistd.h>  // XXX
+
+using namespace ight::common::async;
+using namespace ight::common::pointer;
+using namespace ight::common;
+
+using namespace ight::ooni::http_invalid_request_line;
+
+TEST_CASE("The async engine works as expected") {
+    evthread_use_pthreads();
+    ight_set_verbose(1);
+    Async async;
+    async.run_test(SharedPointer<HTTPInvalidRequestLine>(
+        new HTTPInvalidRequestLine(Settings{
+            {"backend", "http://213.138.109.232/"},
+        })
+    ));
+    async.run_test(SharedPointer<HTTPInvalidRequestLine>(
+        new HTTPInvalidRequestLine(Settings{
+            {"backend", "http://www.google.com/"},
+        })
+    ));
+
+    for (;;) {
+        sleep(1);
+    }
+}

--- a/test/common/async.cpp
+++ b/test/common/async.cpp
@@ -24,7 +24,7 @@
 
 using namespace ight::common::async;
 using namespace ight::common::pointer;
-using namespace ight::common;
+using namespace ight::common::settings;
 
 using namespace ight::ooni::http_invalid_request_line;
 

--- a/test/common/async.cpp
+++ b/test/common/async.cpp
@@ -34,7 +34,7 @@ TEST_CASE("The async engine works as expected") {
     Async async;
     async.run_test(SharedPointer<HTTPInvalidRequestLine>(
         new HTTPInvalidRequestLine(Settings{
-            {"backend", "http://213.138.109.232/"},
+            {"backend", "http://nexa.polito.it/"},
         })
     ));
     async.run_test(SharedPointer<HTTPInvalidRequestLine>(

--- a/test/include.am
+++ b/test/include.am
@@ -7,6 +7,7 @@ check_PROGRAMS =  # Empty
 #
 test_echo_client_evbuf_SOURCES = test/echo_client_evbuf.cpp
 test_echo_client_evbuf_LDADD = libight.la
+test_echo_client_evbuf_LDFLAGS = -lyaml-cpp
 check_PROGRAMS += test/echo_client_evbuf
 
 #
@@ -15,6 +16,7 @@ check_PROGRAMS += test/echo_client_evbuf
 
 test_common_delayed_call_SOURCES = test/common/delayed_call.cpp
 test_common_delayed_call_LDADD = libight.la
+test_common_delayed_call_LDFLAGS = -lyaml-cpp
 check_PROGRAMS += test/common/delayed_call
 TESTS += test/common/delayed_call
 
@@ -25,75 +27,90 @@ TESTS += test/common/log
 
 test_common_evbuffer_SOURCES = test/common/evbuffer.cpp
 test_common_evbuffer_LDADD = libight.la
+test_common_evbuffer_LDFLAGS = -lyaml-cpp
 check_PROGRAMS += test/common/evbuffer
 TESTS += test/common/evbuffer
 
 test_common_bufferevent_SOURCES = test/common/bufferevent.cpp
 test_common_bufferevent_LDADD = libight.la
+test_common_bufferevent_LDFLAGS = -lyaml-cpp
 check_PROGRAMS += test/common/bufferevent
 TESTS += test/common/bufferevent
 
 test_common_poller_SOURCES = test/common/poller.cpp
 test_common_poller_LDADD = libight.la
+test_common_poller_LDFLAGS = -lyaml-cpp
 check_PROGRAMS += test/common/poller
 TESTS += test/common/poller
 
 test_common_pointer_SOURCES = test/common/pointer.cpp
 test_common_pointer_LDADD = libight.la
+test_common_pointer_LDFLAGS = -lyaml-cpp
 check_PROGRAMS += test/common/pointer
 TESTS += test/common/pointer
 
 test_common_socket_valid_SOURCES = test/common/socket_valid.cpp
 test_common_socket_valid_LDADD = libight.la
+test_common_socket_valid_LDFLAGS = -lyaml-cpp
 check_PROGRAMS += test/common/socket_valid
 TESTS += test/common/socket_valid
 
 test_net_buffer_SOURCES = test/net/buffer.cpp
 test_net_buffer_LDADD = libight.la
+test_net_buffer_LDFLAGS = -lyaml-cpp
 check_PROGRAMS += test/net/buffer
 TESTS += test/net/buffer
 
 test_net_connection_SOURCES = test/net/connection.cpp
 test_net_connection_LDADD = libight.la
+test_net_connection_LDFLAGS = -lyaml-cpp
 check_PROGRAMS += test/net/connection
 TESTS += test/net/connection
 
 test_report_file_SOURCES = test/report/file.cpp
 test_report_file_LDADD = libight.la
+test_report_file_LDFLAGS = -lyaml-cpp
 check_PROGRAMS += test/report/file
 TESTS += test/report/file
 
 test_ooni_dns_injection_SOURCES = test/ooni/dns_injection.cpp
 test_ooni_dns_injection_LDADD = libight.la
+test_ooni_dns_injection_LDFLAGS = -lyaml-cpp
 check_PROGRAMS += test/ooni/dns_injection
 TESTS += test/ooni/dns_injection
 
 test_ooni_http_invalid_request_line_SOURCES = test/ooni/http_invalid_request_line.cpp
 test_ooni_http_invalid_request_line_LDADD = libight.la
+test_ooni_http_invalid_request_line_LDFLAGS = -lyaml-cpp
 check_PROGRAMS += test/ooni/http_invalid_request_line
 TESTS += test/ooni/http_invalid_request_line
 
 test_ooni_tcp_test_SOURCES = test/ooni/tcp_test.cpp
 test_ooni_tcp_test_LDADD = libight.la
+test_ooni_tcp_test_LDFLAGS = -lyaml-cpp
 check_PROGRAMS += test/ooni/tcp_test
 TESTS += test/ooni/tcp_test
 
 test_ooni_tcp_connect_SOURCES = test/ooni/tcp_connect.cpp
 test_ooni_tcp_connect_LDADD = libight.la
+test_ooni_tcp_connect_LDFLAGS = -lyaml-cpp
 check_PROGRAMS += test/ooni/tcp_connect
 TESTS += test/ooni/tcp_connect
 
 test_ooni_net_test_SOURCES = test/ooni/net_test.cpp
 test_ooni_net_test_LDADD = libight.la
+test_ooni_net_test_LDFLAGS = -lyaml-cpp
 check_PROGRAMS += test/ooni/net_test
 TESTS += test/ooni/net_test
 
 test_protocols_dns_SOURCES = test/protocols/dns.cpp
 test_protocols_dns_LDADD = libight.la
+test_protocols_dns_LDFLAGS = -lyaml-cpp
 check_PROGRAMS += test/protocols/dns
 TESTS += test/protocols/dns
 
 test_protocols_http_SOURCES = test/protocols/http.cpp
 test_protocols_http_LDADD = libight.la
+test_protocols_http_LDFLAGS = -lyaml-cpp
 check_PROGRAMS += test/protocols/http
 TESTS += test/protocols/http

--- a/test/include.am
+++ b/test/include.am
@@ -14,6 +14,11 @@ check_PROGRAMS += test/echo_client_evbuf
 # The following tests instead are managed by Catch
 #
 
+test_common_async_SOURCES = test/common/async.cpp
+test_common_async_LDADD = libight.la
+check_PROGRAMS += test/common/async
+TESTS += test/common/async
+
 test_common_delayed_call_SOURCES = test/common/delayed_call.cpp
 test_common_delayed_call_LDADD = libight.la
 test_common_delayed_call_LDFLAGS = -lyaml-cpp

--- a/test/protocols/http.cpp
+++ b/test/protocols/http.cpp
@@ -239,6 +239,44 @@ TEST_CASE("HTTP stream works as expected") {
     ight_loop();
 }
 
+TEST_CASE("HTTP stream is robust to EOF") {
+
+    //ight_set_verbose(1);
+
+    // We simulate the receipt of a message terminated by EOF followed by
+    // an EOF so that stream emits in sequence "end" followed by "error(0)"
+    // to check whether the code is prepared for the case in which the
+    // "end" handler deletes the stream.
+
+    auto stream = new http::Stream(Settings{
+        {"dumb_transport", "1"},
+    });
+    stream->on_error([](Error) {
+        /* nothing */
+    });
+    stream->on_end([stream]() {
+        delete stream;
+    });
+
+    auto transport = stream->get_transport();
+
+    stream->on_connect([stream, &transport]() {
+        auto data = std::make_shared<Buffer>();
+
+        *data << "HTTP/1.1 200 Ok\r\n";
+        *data << "Content-Type: text/plain\r\n";
+        *data << "Connection: close\r\n";
+        *data << "Server: Antani/1.0.0.0\r\n";
+        *data << "\r\n";
+        *data << "1234567";
+
+        transport->emit_data(data);
+        transport->emit_error(0);
+    });
+
+    transport->emit_connect();
+}
+
 TEST_CASE("HTTP stream works as expected when using Tor") {
     if (ight::Network::is_down()) {
         return;


### PR DESCRIPTION
This pull request contains the patches needed to move forward iOS application development:

1) bugfix of an use after free bug without which the code to run tests in a background thread (see 3) experienced occasional crashes

2) code needed by the libight-build-ios repository to generate a directory containing libight and all its dependencies libraries and headers without which we cannot recompile a libight for iOS including the code described in 3

3) code to run tests in a background thread that is needed to move forward the iOS app development

Regarding 3, it still needs some love (for example, there are leaks that I am investigating) but before making it perfect I'd say let's merge it and use it in the App to see whether it fullfills our needs.