### PR TITLE
Fix crash when socks5 code is compiled using gcc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq gcc-4.8 g++-4.8
   - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
+  - sudo apt-get install tor
 install: autoreconf -i
 script: ./configure && make && make check-am
 compiler:

--- a/configure.ac
+++ b/configure.ac
@@ -22,7 +22,7 @@ AC_CANONICAL_HOST
 
 # checks for programs
 AC_PROG_INSTALL
-AC_PROG_CXX([clang++ g++ c++])
+AC_PROG_CXX()
 
 # checks for libraries
 

--- a/src/net/transport.cpp
+++ b/src/net/transport.cpp
@@ -21,7 +21,7 @@ using namespace ight::net::connection;
 using namespace ight::net::dumb;
 using namespace ight::net::socks5;
 
-SharedPointer<Transport> connect(Settings settings) {
+static SharedPointer<Transport> connect_internal(Settings settings) {
 
     if (settings.find("dumb_transport") != settings.end()) {
         return std::make_shared<Dumb>();
@@ -53,6 +53,22 @@ SharedPointer<Transport> connect(Settings settings) {
 
     return std::make_shared<Connection>(settings["family"].c_str(),
             settings["address"].c_str(), settings["port"].c_str());
+}
+
+SharedPointer<Transport> connect(Settings settings) {
+    double timeo = -1.0;  // No timeout by default
+    if (settings.find("timeout") != settings.end()) {
+        size_t invalid;
+        timeo = std::stod(settings["timeout"], &invalid);
+        if (invalid != settings["timeout"].length()) {
+            throw std::runtime_error("invalid argument");
+        }
+    }
+    auto transport = connect_internal(settings);
+    if (timeo >= 0.0) {
+        transport->set_timeout(timeo);
+    }
+    return transport;
 }
 
 }}}

--- a/test/protocols/http.cpp
+++ b/test/protocols/http.cpp
@@ -438,6 +438,7 @@ TEST_CASE("HTTP Request correctly receives errors") {
         {"url", "http://nexa.polito.it:81/robots.txt"},
         {"method", "GET"},
         {"http_version", "HTTP/1.1"},
+        {"timeout", "3.0"},
     }, {
         {"Accept", "*/*"},
     }, "", [&](Error error, http::Response&& response) {


### PR DESCRIPTION
This pull request fixes a crash caused by used after free in socks5 code when the code was compiled using gcc. Interestingly, everything was OK when the code was compiled with clang. Detailed discussion and plan to mitigate this issue in 8c992d7 commit message.

In addition to this, I've also commited changes that, if applied earlier, would have allowed us to spot this bug. Namely, now we use the default compiler on Linux (as opposed on clang) which leads to use gcc in most cases. Now, we install Tor on travis-ci so that we test socks5 code also on travis-ci with both gcc and clang on Linux.

Finally, while testing all of this I noticed that an HTTP test took more than one minute to complete and I modified it to take less than four seconds.