### PR TITLE
Android-NDK-integration changes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,74 +1,74 @@
 [core]
-  ignore = dirty
+	ignore = dirty
 [submodule "src/ext/http-parser"]
 	path = src/ext/http-parser
 	url = https://github.com/joyent/http-parser
-  ignore = dirty
+	ignore = dirty
 [submodule "src/ext/libevent"]
 	path = src/ext/libevent
 	url = https://github.com/bassosimone/libevent
-  ignore = dirty
+	ignore = dirty
 [submodule "src/ext/Catch"]
 	path = src/ext/Catch
 	url = https://github.com/philsquared/Catch
-  ignore = dirty
+	ignore = dirty
 [submodule "src/ext/boost/src/iterator"]
 	path = src/ext/boost/iterator
 	url = https://github.com/boostorg/iterator
-  ignore = dirty
+	ignore = dirty
 [submodule "src/ext/boost/src/static_assert"]
 	path = src/ext/boost/static_assert
 	url = https://github.com/boostorg/static_assert
-  ignore = dirty
+	ignore = dirty
 [submodule "src/ext/boost/src/config"]
 	path = src/ext/boost/config
 	url = https://github.com/boostorg/config
-  ignore = dirty
+	ignore = dirty
 [submodule "src/ext/boost/src/core"]
 	path = src/ext/boost/core
 	url = https://github.com/bassosimone/libight-boost-core
-  ignore = dirty
+	ignore = dirty
 [submodule "src/ext/boost/src/mpl"]
 	path = src/ext/boost/mpl
 	url = https://github.com/boostorg/mpl
-  ignore = dirty
+	ignore = dirty
 [submodule "src/ext/boost/src/preprocessor"]
 	path = src/ext/boost/preprocessor
 	url = https://github.com/boostorg/preprocessor
-  ignore = dirty
+	ignore = dirty
 [submodule "src/ext/boost/src/type_traits"]
 	path = src/ext/boost/type_traits
 	url = https://github.com/boostorg/type_traits
-  ignore = dirty
+	ignore = dirty
 [submodule "src/ext/boost/src/detail"]
 	path = src/ext/boost/detail
 	url = https://github.com/boostorg/detail
-  ignore = dirty
+	ignore = dirty
 [submodule "src/ext/boost/src/smart_ptr"]
 	path = src/ext/boost/smart_ptr
 	url = https://github.com/boostorg/smart_ptr
-  ignore = dirty
+	ignore = dirty
 [submodule "src/ext/boost/src/assert"]
 	path = src/ext/boost/assert
 	url = https://github.com/boostorg/assert
-  ignore = dirty
+	ignore = dirty
 [submodule "src/ext/boost/src/throw_exception"]
 	path = src/ext/boost/throw_exception
 	url = https://github.com/boostorg/throw_exception
-  ignore = dirty
+	ignore = dirty
 [submodule "src/ext/boost/src/predef"]
 	path = src/ext/boost/predef
 	url = https://github.com/boostorg/predef
-  ignore = dirty
+	ignore = dirty
 [submodule "src/ext/boost/src/typeof"]
 	path = src/ext/boost/typeof
 	url = https://github.com/boostorg/typeof
-  ignore = dirty
+	ignore = dirty
 [submodule "src/ext/boost/src/utility"]
 	path = src/ext/boost/utility
 	url = https://github.com/boostorg/utility
-  ignore = dirty
+	ignore = dirty
 [submodule "src/ext/yaml-cpp/src/yaml-cpp"]
 	path = src/ext/yaml-cpp
 	url = https://github.com/bassosimone/yaml-cpp.git
-  ignore = dirty
+	ignore = dirty

--- a/.gitmodules
+++ b/.gitmodules
@@ -26,7 +26,7 @@
   ignore = dirty
 [submodule "src/ext/boost/src/core"]
 	path = src/ext/boost/core
-	url = https://github.com/boostorg/core
+	url = https://github.com/bassosimone/libight-boost-core
   ignore = dirty
 [submodule "src/ext/boost/src/mpl"]
 	path = src/ext/boost/mpl

--- a/test/include.am
+++ b/test/include.am
@@ -16,6 +16,7 @@ check_PROGRAMS += test/echo_client_evbuf
 
 test_common_async_SOURCES = test/common/async.cpp
 test_common_async_LDADD = libight.la
+test_common_async_LDFLAGS = -lyaml-cpp
 check_PROGRAMS += test/common/async
 TESTS += test/common/async
 
@@ -27,6 +28,7 @@ TESTS += test/common/delayed_call
 
 test_common_log_SOURCES = test/common/log.cpp
 test_common_log_LDADD = libight.la
+test_common_log_LDFLAGS = -lyaml-cpp
 check_PROGRAMS += test/common/log
 TESTS += test/common/log
 


### PR DESCRIPTION
With the following changes merged, I am able to cross-compile libight for Android for ARM, MIPS and android-86 (see [libight-build-android](https://github.com/TheTorProject/libight-build-android)).

After this change, **remember to run** `git submodule sync` because I have changed the URL of boost/core repository to point to our personal fork.