### PR TITLE
Use the system-wide DNS resolver for the connectivity check

### DIFF
--- a/include/ight/common/check_connectivity.hpp
+++ b/include/ight/common/check_connectivity.hpp
@@ -36,12 +36,13 @@ using namespace ight::common::constraints;
  *         return;
  *     }
  *
- * \remark This class reports that the network is up if 8.8.4.4 works and
- * returns a valid IPv4 address for nexa.polito.it. To reach 8.8.4.4 we use
- * evdns, which we assume to be working. If evdns is broken, 8.8.4.4 is not
- * reachable or nexa.polito.it is no longer available, this class reports that
- * the network is down even if it is not actually down. All these three
- * conditions are quite unlikely, IMO, so this code should be robust enough.
+ * \remark This class reports that the network is up if the system-wide DNS
+ * resolver works and returns a valid IPv4 address for nexa.polito.it. To reach
+ * the DNS resolver we use evdns, which we assume to be working. If evdns is
+ * broken, the DNS resolver is not reachable or nexa.polito.it is no longer
+ * available, this class reports that the network is down even if it is not
+ * actually down. All these three conditions are quite unlikely, IMO, so this
+ * code should be robust enough.
  *
  * \remark The check on whether the network is down is performed only
  * once when is_down() is called for the first time. Therefore, this

--- a/include/ight/common/check_connectivity.hpp
+++ b/include/ight/common/check_connectivity.hpp
@@ -37,12 +37,12 @@ using namespace ight::common::constraints;
  *     }
  *
  * \remark This class reports that the network is up if the system-wide DNS
- * resolver works and returns a valid IPv4 address for nexa.polito.it. To reach
- * the DNS resolver we use evdns, which we assume to be working. If evdns is
- * broken, the DNS resolver is not reachable or nexa.polito.it is no longer
- * available, this class reports that the network is down even if it is not
- * actually down. All these three conditions are quite unlikely, IMO, so this
- * code should be robust enough.
+ * resolver works and returns a valid IPv4 address for ebay.com. To reach the
+ * DNS resolver we use evdns, which we assume to be working. If evdns is broken,
+ * the DNS resolver is not reachable or ebay.com is no longer available, this
+ * class reports that the network is down even if it is not actually down. All
+ * these three conditions are quite unlikely, IMO, so this code should be robust
+ * enough.
  *
  * \remark The check on whether the network is down is performed only
  * once when is_down() is called for the first time. Therefore, this

--- a/src/common/check_connectivity.cpp
+++ b/src/common/check_connectivity.cpp
@@ -65,10 +65,10 @@ Network::Network(void)
         throw std::bad_alloc();
     }
 
-    if (evdns_base_resolve_ipv4(dnsbase, "nexa.polito.it", DNS_QUERY_NO_SEARCH,
+    if (evdns_base_resolve_ipv4(dnsbase, "ebay.com", DNS_QUERY_NO_SEARCH,
                                 dns_callback, this) == NULL) {
         cleanup();
-        throw std::runtime_error("cannot resolve 'nexa.polito.it'");
+        throw std::runtime_error("cannot resolve 'ebay.com'");
     }
 
     if (event_base_dispatch(evbase) != 0) {

--- a/src/common/check_connectivity.cpp
+++ b/src/common/check_connectivity.cpp
@@ -41,12 +41,20 @@ Network::dns_callback(int result, char type, int count, int ttl,
     (void) ttl;
     (void) addresses;
 
-    //
-    // TODO: The following check is good for the unit test but, to be
-    // precise, there are other error conditions that can indicate that
-    // we have connectivity (e.g., DNS_ERR_NOTEXIST).
-    //
-    that->is_up = (result == DNS_ERR_NONE);
+    switch (result) {
+    case DNS_ERR_NONE:
+    case DNS_ERR_FORMAT:
+    case DNS_ERR_SERVERFAILED:
+    case DNS_ERR_NOTEXIST:
+    case DNS_ERR_NOTIMPL:
+    case DNS_ERR_REFUSED:
+    case DNS_ERR_TRUNCATED:
+    case DNS_ERR_NODATA:
+        that->is_up = true;
+        break;
+    default:
+        that->is_up = false;
+    }
 
     if (event_base_loopbreak(that->evbase) != 0) {
         throw std::runtime_error("Cannot exit from event loop");

--- a/src/common/check_connectivity.cpp
+++ b/src/common/check_connectivity.cpp
@@ -60,13 +60,9 @@ Network::Network(void)
         throw std::bad_alloc();
     }
 
-    if ((dnsbase = evdns_base_new(evbase, 0)) == NULL) {
+    if ((dnsbase = evdns_base_new(evbase, 1)) == NULL) {
         cleanup();
         throw std::bad_alloc();
-    }
-    if (evdns_base_nameserver_ip_add(dnsbase, "8.8.4.4") != 0) {
-        cleanup();
-        throw std::runtime_error("cannot add IP address");
     }
 
     if (evdns_base_resolve_ipv4(dnsbase, "nexa.polito.it", DNS_QUERY_NO_SEARCH,


### PR DESCRIPTION
As @bassosimone suggested, the Google public DNS might be blocked
in some countries. So, it is more robust to use the default system
resolver to query for the IP address of nexa.polito.it.