### PR TITLE
Fix gcc warning

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,7 +12,7 @@ ACLOCAL_AMFLAGS = -I m4
 
 LIBIGHT_I_FLAGS = -I $(top_srcdir)/include
 LIBIGHT_I_FLAGS += -I $(top_srcdir)/src
-LIBIGHT_W_FLAGS = -Wall -Wmissing-prototypes -Wextra -pedantic
+LIBIGHT_W_FLAGS = -Wall -Wextra -pedantic
 
 VERSION_INFO = 4:0:0
 AM_CFLAGS = -pthread $(LIBIGHT_W_FLAGS) $(LIBIGHT_I_FLAGS)

--- a/configure.ac
+++ b/configure.ac
@@ -255,6 +255,25 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <functional>],
 CXXFLAGS="$ight_saved_cxxflags $ight_cxx_stdlib_flags"
 AC_LANG_POP([C++])
 
+ight_saved_cxxflags="$CXXFLAGS"
+CXXFLAGS="-Werror -Wmissing-prototypes"
+ight_cxx_stdlib_flags=""
+AC_MSG_CHECKING([whether the C++ compiler supports -Wmissing-prototypes])
+AC_LANG_PUSH([C++])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <string>],
+                                    [std::string s;]])],
+    [
+     AC_MSG_RESULT([yes])
+     ight_cxx_missing_prototypes="-Wmissing-prototypes"
+    ]
+    [],
+    [
+     AC_MSG_RESULT([no])
+    ]
+)
+CXXFLAGS="$ight_saved_cxxflags $ight_cxx_missing_prototypes"
+AC_LANG_POP([C++])
+
 # checks for library functions
 # checks for system services
 

--- a/configure.ac
+++ b/configure.ac
@@ -238,7 +238,7 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <functional>],
      #
      AC_MSG_CHECKING([whether libc++ is available])
      CXXFLAGS="-std=c++11 -stdlib=libc++"
-     AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <functional>],
+     AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <functional>]
                                          [std::function<void(void)> f;]])],
         [
          AC_MSG_RESULT([yes])
@@ -260,7 +260,7 @@ CXXFLAGS="-Werror -Wmissing-prototypes"
 ight_cxx_stdlib_flags=""
 AC_MSG_CHECKING([whether the C++ compiler supports -Wmissing-prototypes])
 AC_LANG_PUSH([C++])
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <string>],
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <string>]
                                     [std::string s;]])],
     [
      AC_MSG_RESULT([yes])


### PR DESCRIPTION
GCC does not implement `-Wmissing-prototypes` therefore teach `./configure` to only set this flag when the compiler supports it (currently, when we se clang).